### PR TITLE
reverse lookup by currency

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -53,6 +53,13 @@ describe("getRegionByCode()", function() {
   });
 });
 
+describe("getRegionByCurrency()", function() {
+  it("should return region from currency code", function() {
+    const region = regionModule.getRegionByCurrency("AUD", "luxuryescapes")
+    expect(region ? region.code : 'fail test if region undefined').to.equal("AU");
+  });
+});
+
 describe("getRegionNameByCode()", function() {
   it("returns region name if region exists", function() {
     expect(regionModule.getRegionNameByCode("AU", "scoopontravel")).to.equal("Australia");

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,13 @@ export function getRegionByCode(regionCode: string, brand?: string) {
   return regions(brand).find((region) => (region.code.toLowerCase() === regionCode.toLowerCase()));
 }
 
+export function getRegionByCurrency(currencyCode: string, brand?: string) {
+  if (!currencyCode) {
+    return null;
+  }
+  return regions(brand).find((region) => (region.currencyCode.toLowerCase() === currencyCode.toLowerCase()));
+}
+
 export function getDefaultRegion(brand?: string) {
   return regions(brand)[0];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,9 +34,6 @@ export function getRegionByCode(regionCode: string, brand?: string) {
 }
 
 export function getRegionByCurrency(currencyCode: string, brand?: string) {
-  if (!currencyCode) {
-    return null;
-  }
   return regions(brand).find((region) => (region.currencyCode.toLowerCase() === currencyCode.toLowerCase()));
 }
 


### PR DESCRIPTION
Using a currency to find a region.

Doing this so that we can reverse lookup from a currency to a region for the credits journey.

When reverse lookup is done on **EUR** the result is always **FR** the marketing team are happy with this as a user will still be able to see their credits.
