### PR TITLE
rename payment provider from bridger_pay to bridgerpay to avoid extra underscore

### DIFF
--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -102,7 +102,7 @@ export const currencies: BrandCurrencies = {
         "latitude_pay",
         "giftcard",
         "klarna",
-        "bridger_pay",
+        "bridgerpay",
       ],
     },
     CAD: {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -160,7 +160,7 @@ describe("getPaymentMethodsByCurrencyCode()", function() {
       "latitude_pay",
       "giftcard",
       "klarna",
-      "bridger_pay",
+      "bridgerpay",
     ]);
   });
 


### PR DESCRIPTION
Lets rename the bridger_pay to bridgerpay to avoid underscore unnecessarily