### PR TITLE
Enable 'applepay' for AUD

### DIFF
--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -103,6 +103,7 @@ export const currencies: BrandCurrencies = {
         "giftcard",
         "klarna",
         "bridgerpay",
+        "applepay",
       ],
     },
     CAD: {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -161,6 +161,7 @@ describe("getPaymentMethodsByCurrencyCode()", function() {
       "giftcard",
       "klarna",
       "bridgerpay",
+      "applepay",
     ]);
   });
 


### PR DESCRIPTION
Added support for 'applepay' for AUD for the following epic:
https://aussiecommerce.atlassian.net/browse/PP-221