### PR TITLE
v4.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "4.6.9",
+  "version": "4.7.0",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
Follow up PR to the following PR for adding applepay to payment methods for AUD currency:
https://github.com/lux-group/lib-regions/pull/174

In this PR:
Publishing a new version which contains 'applepay' as payment method for AUD
Bumped version from v4.6.9 to v4.7.0 during yarn publish.
Publish was succesful.
<img width="904" alt="Screenshot 2021-08-19 at 8 47 39 PM" src="https://user-images.githubusercontent.com/83265766/130095225-ab446be5-f6c2-48f4-8c27-eab162551518.png">
