### PR TITLE
enable apple pay and or google pay whereever applicable

### DIFF
--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -112,6 +112,8 @@ export const currencies: BrandCurrencies = {
         "le_credit",
         "stripe",
         "giftcard",
+        "applepay",
+        "googlepay",
       ],
     },
     CNY: {
@@ -120,6 +122,7 @@ export const currencies: BrandCurrencies = {
         "stripe",
         "giftcard",
         "krisFlyer",
+        "applepay",
       ],
     },
     EUR: {
@@ -127,6 +130,8 @@ export const currencies: BrandCurrencies = {
         "le_credit",
         "stripe",
         "giftcard",
+        "applepay",
+        "googlepay",
       ],
     },
     HKD: {
@@ -135,6 +140,8 @@ export const currencies: BrandCurrencies = {
         "stripe",
         "giftcard",
         "krisFlyer",
+        "applepay",
+        "googlepay",
       ],
     },
     INR: {
@@ -152,6 +159,7 @@ export const currencies: BrandCurrencies = {
         "stripe",
         "giftcard",
         "krisFlyer",
+        "googlepay",
       ],
     },
     ILS: {
@@ -159,6 +167,8 @@ export const currencies: BrandCurrencies = {
         "le_credit",
         "stripe",
         "giftcard",
+        "applepay",
+        "googlepay",
       ],
     },
     JPY: {
@@ -167,6 +177,8 @@ export const currencies: BrandCurrencies = {
         "stripe",
         "giftcard",
         "krisFlyer",
+        "applepay",
+        "googlepay",
       ],
     },
     KRW: {
@@ -182,6 +194,7 @@ export const currencies: BrandCurrencies = {
         "le_credit",
         "stripe",
         "giftcard",
+        "applepay",
       ],
     },
     MYR: {
@@ -190,6 +203,7 @@ export const currencies: BrandCurrencies = {
         "stripe",
         "giftcard",
         "krisFlyer",
+        "googlepay",
       ],
     },
     NZD: {
@@ -199,6 +213,8 @@ export const currencies: BrandCurrencies = {
         "giftcard",
         "krisFlyer",
         "bridgerpay",
+        "applepay",
+        "googlepay",
       ],
     },
     PHP: {
@@ -207,6 +223,7 @@ export const currencies: BrandCurrencies = {
         "stripe",
         "giftcard",
         "krisFlyer",
+        "googlepay",
       ],
     },
     QAR: {
@@ -214,6 +231,8 @@ export const currencies: BrandCurrencies = {
         "le_credit",
         "stripe",
         "giftcard",
+        "applepay",
+        "googlepay",
       ],
     },
     RUB: {
@@ -221,6 +240,8 @@ export const currencies: BrandCurrencies = {
         "le_credit",
         "stripe",
         "giftcard",
+        "applepay",
+        "googlepay",
       ],
     },
     SAR: {
@@ -228,6 +249,8 @@ export const currencies: BrandCurrencies = {
         "le_credit",
         "stripe",
         "giftcard",
+        "applepay",
+        "googlepay",
       ],
     },
     SGD: {
@@ -236,6 +259,8 @@ export const currencies: BrandCurrencies = {
         "stripe",
         "giftcard",
         "krisFlyer",
+        "applepay",
+        "googlepay",
       ],
     },
     TWD: {
@@ -244,6 +269,8 @@ export const currencies: BrandCurrencies = {
         "stripe",
         "giftcard",
         "krisFlyer",
+        "applepay",
+        "googlepay",
       ],
     },
     THB: {
@@ -252,6 +279,7 @@ export const currencies: BrandCurrencies = {
         "stripe",
         "giftcard",
         "krisFlyer",
+        "googlepay",
       ],
     },
     ZAR: {
@@ -259,6 +287,8 @@ export const currencies: BrandCurrencies = {
         "le_credit",
         "stripe",
         "giftcard",
+        "applepay",
+        "googlepay",
       ],
     },
     AED: {
@@ -266,6 +296,8 @@ export const currencies: BrandCurrencies = {
         "le_credit",
         "stripe",
         "giftcard",
+        "applepay",
+        "googlepay",
       ],
     },
     GBP: {
@@ -274,6 +306,8 @@ export const currencies: BrandCurrencies = {
         "stripe",
         "giftcard",
         "krisFlyer",
+        "applepay",
+        "googlepay",
       ],
     },
     USD: {
@@ -282,6 +316,8 @@ export const currencies: BrandCurrencies = {
         "stripe",
         "giftcard",
         "krisFlyer",
+        "applepay",
+        "googlepay",
       ],
     },
     VND: {
@@ -290,6 +326,7 @@ export const currencies: BrandCurrencies = {
         "stripe",
         "giftcard",
         "krisFlyer",
+        "googlepay",
       ],
     },
   },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -173,6 +173,8 @@ describe("getPaymentMethodsByCurrencyCode()", function() {
       "stripe",
       "giftcard",
       "krisFlyer",
+      "applepay",
+      "googlepay",
     ]);
   });
 


### PR DESCRIPTION
enable google pay and or apple pay for different currencies wherever applicable.

References:
https://support.apple.com/en-us/HT207957
https://support.google.com/pay/india/answer/9023773?hl=en#zippy=%2Cpay-online-or-in-apps%2Cbuy-google-products%2Cpay-using-info-saved-to-chrome