### PR TITLE
PP 272 Enable klarna_bp for USD GBP NZD

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -215,6 +215,7 @@ export const currencies: BrandCurrencies = {
         "bridgerpay",
         "applepay",
         "googlepay",
+        "klarna_bp",
       ],
     },
     PHP: {
@@ -308,6 +309,7 @@ export const currencies: BrandCurrencies = {
         "krisFlyer",
         "applepay",
         "googlepay",
+        "klarna_bp",
       ],
     },
     USD: {
@@ -318,6 +320,7 @@ export const currencies: BrandCurrencies = {
         "krisFlyer",
         "applepay",
         "googlepay",
+        "klarna_bp",
       ],
     },
     VND: {


### PR DESCRIPTION
Story for reference:
https://aussiecommerce.atlassian.net/browse/PP-272

We need to introduce Klarna as a payment option for USD, NZD and GBP. This is being done via bridgerpay. We have introduced a new payment option 'klarna_bp' for this purpose.

The new changes have been published with version 4.8.3
![Screen Shot 2021-09-17 at 11 55 11 am](https://user-images.githubusercontent.com/83265766/133734784-d7b97af6-081e-4479-ae67-be9b068491c0.png)
