### PR TITLE
Turn back klarna

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "4.8.5",
+  "version": "4.8.6",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -215,7 +215,7 @@ export const currencies: BrandCurrencies = {
         "bridgerpay",
         "applepay",
         "googlepay",
-        // "klarna_bp",
+        "klarna_bp",
       ],
     },
     PHP: {
@@ -309,7 +309,7 @@ export const currencies: BrandCurrencies = {
         "krisFlyer",
         "applepay",
         "googlepay",
-        // "klarna_bp",
+        "klarna_bp",
       ],
     },
     USD: {
@@ -320,7 +320,7 @@ export const currencies: BrandCurrencies = {
         "krisFlyer",
         "applepay",
         "googlepay",
-        // "klarna_bp",
+        "klarna_bp",
       ],
     },
     VND: {


### PR DESCRIPTION
Klarna was turned off in https://github.com/lux-group/lib-regions/pull/186

This is for releasing the blackout of apple pay and google pay in unsupported regions in: https://github.com/lux-group/lib-regions/pull/185

Original PR: https://github.com/lux-group/lib-regions/pull/184