### PR TITLE
Added afterpay_bp for nz

### DIFF
--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -213,7 +213,7 @@ export const currencies: BrandCurrencies = {
         "stripe",
         "giftcard",
         "krisFlyer",
-        "bridgerpay",
+        "afterpay_bp",
         "applepay",
         "googlepay",
         "klarna_bp",


### PR DESCRIPTION
Need to change from bridgerpay to afterpay_bp . we dont have to support bridgerpay here as this is noty live on NZD currency