### PR TITLE
Added a new dummy white label brand

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -11,7 +11,7 @@
     "src"
   ],
   "scripts": {
-    "build": "rm -rf lib && tsc",
+    "build": "npx rimraf -rf lib && tsc",
     "test": "mocha -r ts-node/register src/index.test.ts",
     "lint": "tslint -p tsconfig.json",
     "lint-fix": "tslint --fix -p tsconfig.json",
@@ -27,6 +27,7 @@
     "mocha": "^6.2.0",
     "ts-node": "^8.3.0",
     "tslint": "^5.19.0",
-    "typescript": "^3.6.2"
+    "typescript": "^3.6.2",
+    "rimraf": "^3.0.2"
   }
 }

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -352,4 +352,251 @@ export const currencies: BrandCurrencies = {
       ],
     },
   },
+  newwhitelabel: {
+      AUD: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "braintree",
+          "qantas",
+          "latitude",
+          "latitude_gem",
+          "latitude_pay",
+          "giftcard",
+          "klarna",
+          "bridgerpay",
+          "applepay",
+          "googlepay",
+          "afterpay_bp",
+        ],
+      },
+      CAD: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          "applepay",
+          "googlepay",
+        ],
+      },
+      CNY: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          "krisFlyer",
+          "applepay",
+        ],
+      },
+      EUR: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          "applepay",
+          "googlepay",
+        ],
+      },
+      HKD: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          "krisFlyer",
+          "applepay",
+          "googlepay",
+          "hoolah_bp",
+        ],
+      },
+      INR: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "razorpay",
+          "giftcard",
+          "vistara",
+        ],
+      },
+      IDR: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          "krisFlyer",
+          "googlepay",
+        ],
+      },
+      ILS: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          // "applepay",  // Apple Pay is not supported in IL
+          // "googlepay", // Google Pay is not supported in IL
+        ],
+      },
+      JPY: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          "krisFlyer",
+          "applepay",
+          "googlepay",
+        ],
+      },
+      KRW: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          "krisFlyer",
+        ],
+      },
+      MOP: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          "applepay",
+        ],
+      },
+      MYR: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          "krisFlyer",
+          "googlepay",
+          "hoolah_bp",
+        ],
+      },
+      NZD: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          "krisFlyer",
+          "afterpay_bp",
+          "applepay",
+          "googlepay",
+          "klarna_bp",
+        ],
+      },
+      PHP: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          "krisFlyer",
+          "googlepay",
+        ],
+      },
+      QAR: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          // "applepay",  // Apple Pay is not supported in QA
+          // "googlepay", // Google Pay is not supported in QA
+        ],
+      },
+      RUB: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          // "applepay", // Apple Pay is not supported in RU
+          // "googlepay", // Google Pay is not supported in RU
+        ],
+      },
+      SAR: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          // "applepay", // Apple Pay is not supported in SA
+          // "googlepay", // Google Pay is not supported in SA
+        ],
+      },
+      SGD: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          "krisFlyer",
+          "applepay",
+          "googlepay",
+          "hoolah_bp",
+        ],
+      },
+      TWD: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          "krisFlyer",
+          "applepay",
+          "googlepay",
+        ],
+      },
+      THB: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          "krisFlyer",
+          "googlepay",
+        ],
+      },
+      ZAR: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          // "applepay", Apple Pay is not supported in South Africa
+          // "googlepay", Google Pay is not supported in South Africa
+        ],
+      },
+      AED: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          "applepay",
+          "googlepay",
+        ],
+      },
+      GBP: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          "krisFlyer",
+          "applepay",
+          "googlepay",
+          "klarna_bp",
+        ],
+      },
+      USD: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          "krisFlyer",
+          "applepay",
+          "googlepay",
+          "klarna_bp",
+        ],
+      },
+      VND: {
+        paymentMethods: [
+          "le_credit",
+          "stripe",
+          "giftcard",
+          "krisFlyer",
+          // "googlepay", // Google Pay is not supported in South Africa
+        ],
+      },
+  },
 };

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,10 +7,55 @@ describe("getRegionCodes()", function() {
   });
 });
 
+const expectedLeRegions = [
+  "Australia",
+  "Canada",
+  "China",
+  "France",
+  "Germany",
+  "Hong Kong",
+  "India",
+  "Indonesia",
+  "Ireland",
+  "Israel",
+  "Italy",
+  "Japan",
+  "Korea",
+  "Macau",
+  "Malaysia",
+  "Netherlands",
+  "New Zealand",
+  "Philippines",
+  "Qatar",
+  "Russia",
+  "Saudi Arabia",
+  "Singapore",
+  "South Africa",
+  "Spain",
+  "Taiwan",
+  "Thailand",
+  "United Arab Emirates",
+  "United Kingdom",
+  "United States",
+  "Vietnam",
+];
+
 describe("getRegionNames()", function() {
-  it("should return an array of region names", function() {
-    expect(regionModule.getRegionNames("scoopontravel")).to.deep.equal(["Australia"]);
-  });
+  const cases: [string, string[]][] = [
+    ['luxuryescapes', expectedLeRegions],
+    ['scoopontravel', ['Australia']],
+    ['cudotravel', ['Australia']],
+    ['treatmetravel', ['New Zealand']],
+    ['dealstravel', ['Australia']],
+    ['yidu', ['China']],
+    ['zoomzoom', ['Korea', 'Australia']],
+    ['newwhitelabel', ['Australia']],
+  ];
+  cases.forEach(([brand, expectedRegions]) => {
+    it(`when the brand "${brand}" is passed as an argument to getRegionNames(brand), the function should return ${expectedRegions}`, () => {
+      expect(regionModule.getRegionNames(brand)).to.deep.equal(expectedRegions);
+    })
+  })
 
   it("should return an array of region names default brand to luxuryescapes", function() {
     expect(regionModule.getRegionNames()).to.deep.equal([

--- a/src/regions.ts
+++ b/src/regions.ts
@@ -1652,4 +1652,48 @@ export const regions: BrandRegions = {
       offerUrgencyTag: null,
     },
   ],
+  newwhitelabel: [
+    {
+      code: "AU",
+      name: "Australia",
+      lang: "en-AU",
+      phonePrefix: "61",
+      currencyFormattingLocale: "en-AU",
+      currencyCode: "AUD",
+      currencyPrefix: "A",
+      flagId: "au_iuox02",
+      flightsSupportEmail: DEFAULT_FLIGHTS_SUPPORT_EMAIL,
+      phone: {
+        local: {
+          humanReadable: "1300 88 99 00",
+          number: "1300889900",
+        },
+        international: {
+          humanReadable: "+61 2 8320 6845",
+          number: "+61283206845",
+        },
+        default: "international",
+      },
+      mailingAddress: DEFAULT_MAILING_ADDRESS,
+      latitudeThreshold: 999,
+      referralAmount: 50,
+      insuranceProductName: "insurance",
+      referralMinSpendAmount: 499,
+      giftCardOptions: [50, 100, 250, 500, 1000, 2000, 4000, 5000],
+      offerUrgencyTag: {
+        tour: {
+          popular: {
+            min: 2,
+            period: 24,
+          },
+        },
+        hotel: {
+          popular: {
+            min: 10,
+            period: 24,
+          },
+        },
+      },
+    },
+  ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -342,6 +342,18 @@ glob@7.1.3, glob@^7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.1.3:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
@@ -709,6 +721,13 @@ resolve@^1.3.2:
   integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
   dependencies:
     path-parse "^1.0.5"
+
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
 
 semver@^5.3.0:
   version "5.6.0"


### PR DESCRIPTION
PR:

I was given a task by Joss to create a dummy white label brand. Adding new NWL entries to lib-region seems to be a pre-requisite as it is dependent on by other services / repositories.

I've tested that the enum works locally by setting this library in svc-offer, svc-public-offer, and www-le-customer, updating a few places (where brand whitelisting is hardcoded) in the codebases, and creating a custom schedule for the newwhitelabel brand so public offers would show the offer.