### PR TITLE
Add stripe_3ds as payment method for NZD

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "4.10.3",
+  "version": "4.10.4",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -232,6 +232,7 @@ export const currencies: BrandCurrencies = {
         "applepay",
         "googlepay",
         "klarna_bp",
+        "stripe_3ds",
       ],
     },
     PHP: {


### PR DESCRIPTION
Adding stripe_3ds to list of payment methods valid for NZD currency as part of Stripe 3DS release across NZD
<img width="918" alt="Screen Shot 2022-03-07 at 12 59 03 pm" src="https://user-images.githubusercontent.com/83265766/156986853-6dd4e837-1bc7-41fe-ab3b-b4fa6389cb03.png">
 