### PR TITLE
Enable stripe3ds for GBP

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "4.10.4",
+  "version": "4.10.5",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -338,6 +338,7 @@ export const currencies: BrandCurrencies = {
         "applepay",
         "googlepay",
         "klarna_bp",
+        "stripe_3ds",
       ],
     },
     USD: {


### PR DESCRIPTION
This PR adds payment type stripe3DS for GB.
npm publish details:
<img width="897" alt="Screen Shot 2022-03-15 at 9 27 15 am" src="https://user-images.githubusercontent.com/83265766/158303395-489d299a-256c-42b8-9271-952b9b63fefa.png">