### PR TITLE
Enable stripe 3DS USD AUD SGD

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "4.10.5",
+  "version": "4.10.7",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -107,6 +107,7 @@ export const currencies: BrandCurrencies = {
         "applepay",
         "googlepay",
         "afterpay_bp",
+        "stripe_3ds",
       ],
     },
     CAD: {
@@ -285,6 +286,7 @@ export const currencies: BrandCurrencies = {
         "applepay",
         "googlepay",
         "hoolah_bp",
+        "stripe_3ds",
       ],
     },
     TWD: {
@@ -352,6 +354,7 @@ export const currencies: BrandCurrencies = {
         "googlepay",
         "klarna_bp",
         "afterpay_bp",
+        "stripe_3ds",
       ],
     },
     VND: {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -211,6 +211,7 @@ describe("getPaymentMethodsByCurrencyCode()", function() {
       "applepay",
       "googlepay",
       "afterpay_bp",
+      "stripe_3ds",
     ]);
   });
 
@@ -224,6 +225,7 @@ describe("getPaymentMethodsByCurrencyCode()", function() {
       "applepay",
       "googlepay",
       "hoolah_bp",
+      "stripe_3ds",
     ]);
   });
 


### PR DESCRIPTION
PR to enable 3DS Stripe payment option for USD, AUD and SGD currencies
![Screen Shot 2022-03-23 at 5 55 38 pm](https://user-images.githubusercontent.com/83265766/159698808-eab6d0b0-bb2f-4043-a78b-c428407bcdc6.png)

