### PR TITLE
[OPEX-310] fix human readable priority phone number format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "4.10.9",
+  "version": "4.10.10",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/priorityPhoneNumbers.ts
+++ b/src/priorityPhoneNumbers.ts
@@ -29,7 +29,7 @@ export const priorityPhoneNumbers: BrandPriorityPhoneNumber = {
       phonePrefix: "61",
       phone: {
         local: {
-          humanReadable: "1300 860 454",
+          humanReadable: "1300 86 04 54",
           number: "1300860454",
         },
         international: {


### PR DESCRIPTION
Fix phone number format to be the same as other numbers in lib-region