### PR TITLE
DEVX-78: changing default region from AU to US for luxuryEscapes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "4.10.10",
+  "version": "4.10.11",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,6 +8,7 @@ describe("getRegionCodes()", function() {
 });
 
 const expectedLeRegions = [
+  "United States",
   "Australia",
   "Canada",
   "China",
@@ -36,7 +37,6 @@ const expectedLeRegions = [
   "Thailand",
   "United Arab Emirates",
   "United Kingdom",
-  "United States",
   "Vietnam",
 ];
 
@@ -59,6 +59,7 @@ describe("getRegionNames()", function() {
 
   it("should return an array of region names default brand to luxuryescapes", function() {
     expect(regionModule.getRegionNames()).to.deep.equal([
+      "United States",
       "Australia",
       "Canada",
       "China",
@@ -87,7 +88,6 @@ describe("getRegionNames()", function() {
       "Thailand",
       "United Arab Emirates",
       "United Kingdom",
-      "United States",
       "Vietnam",
     ]);
   });
@@ -128,11 +128,11 @@ describe("getDefaultRegion()", function() {
 
 describe("getDefaultRegionCode()", function() {
   it("should return the default region's code", function() {
-    expect(regionModule.getDefaultRegionCode("luxuryescapes")).to.equal("AU");
+    expect(regionModule.getDefaultRegionCode("luxuryescapes")).to.equal("US");
   });
 
   it("should return the default region's code default brand to luxuryescapes", function() {
-    expect(regionModule.getDefaultRegionCode()).to.equal("AU");
+    expect(regionModule.getDefaultRegionCode()).to.equal("US");
   });
 
   it("should return the default region for the brand", function() {
@@ -146,7 +146,7 @@ describe("getDefaultRegionName()", function() {
   });
 
   it("should return the default region's name default brand to luxuryescapes", function() {
-    expect(regionModule.getDefaultRegionName()).to.equal("Australia");
+    expect(regionModule.getDefaultRegionName()).to.equal("United States");
   });
 });
 
@@ -254,6 +254,7 @@ describe("getRegionLang()", function() {
 
   it("should return an array of region langs default brand to luxuryescapes", function() {
     expect(regionModule.getRegionLang()).to.deep.equal([
+      "en-US",
       "en-AU",
       "en-CA",
       "en-CN",
@@ -269,7 +270,7 @@ describe("getRegionLang()", function() {
       "en-KR",
       "en-MO",
       "en-MY",
-      "en-NL",  
+      "en-NL",
       "en-NZ",
       "en-PH",
       "en-QA",
@@ -282,7 +283,6 @@ describe("getRegionLang()", function() {
       "en-TH",
       "en-AE",
       "en-GB",
-      "en-US",
       "en-VN",
     ]);
   });

--- a/src/regions.ts
+++ b/src/regions.ts
@@ -54,6 +54,47 @@ const DEFAULT_FLIGHTS_SUPPORT_EMAIL = "flights@luxuryescapes.com";
 export const regions: BrandRegions = {
   luxuryescapes: [
     {
+      code: "US",
+      name: "United States",
+      lang: "en-US",
+      phonePrefix: "1",
+      currencyFormattingLocale: "en-US",
+      currencyCode: "USD",
+      currencyPrefix: "US",
+      flagId: "us_fapjn8",
+      flightsSupportEmail: DEFAULT_FLIGHTS_SUPPORT_EMAIL,
+      phone: {
+        local: {
+          humanReadable: "888 809 6860",
+          number: "8888096860",
+        },
+        international: {
+          humanReadable: "+61 2 8320 6845",
+          number: "+61283206845",
+        },
+        default: "international",
+      },
+      mailingAddress: DEFAULT_MAILING_ADDRESS,
+      referralAmount: 50,
+      insuranceProductName: "protection",
+      referralMinSpendAmount: 500,
+      giftCardOptions: [50, 100, 250, 500, 1000, 2000],
+      offerUrgencyTag: {
+        tour: {
+          popular: {
+            min: 2,
+            period: 24,
+          },
+        },
+        hotel: {
+          popular: {
+            min: 4,
+            period: 24,
+          },
+        },
+      },
+    },
+    {
       code: "AU",
       name: "Australia",
       lang: "en-AU",
@@ -1186,47 +1227,6 @@ export const regions: BrandRegions = {
       referralAmount: 25,
       insuranceProductName: "protection",
       referralMinSpendAmount: 249,
-      giftCardOptions: [50, 100, 250, 500, 1000, 2000],
-      offerUrgencyTag: {
-        tour: {
-          popular: {
-            min: 2,
-            period: 24,
-          },
-        },
-        hotel: {
-          popular: {
-            min: 4,
-            period: 24,
-          },
-        },
-      },
-    },
-    {
-      code: "US",
-      name: "United States",
-      lang: "en-US",
-      phonePrefix: "1",
-      currencyFormattingLocale: "en-US",
-      currencyCode: "USD",
-      currencyPrefix: "US",
-      flagId: "us_fapjn8",
-      flightsSupportEmail: DEFAULT_FLIGHTS_SUPPORT_EMAIL,
-      phone: {
-        local: {
-          humanReadable: "888 809 6860",
-          number: "8888096860",
-        },
-        international: {
-          humanReadable: "+61 2 8320 6845",
-          number: "+61283206845",
-        },
-        default: "international",
-      },
-      mailingAddress: DEFAULT_MAILING_ADDRESS,
-      referralAmount: 50,
-      insuranceProductName: "protection",
-      referralMinSpendAmount: 500,
       giftCardOptions: [50, 100, 250, 500, 1000, 2000],
       offerUrgencyTag: {
         tour: {


### PR DESCRIPTION
There was a request to change default region from AU to US when it cannot be determined/not supported.

"Any idea why I'd be seeing AUD on the mobile website if I'm not logged in and my IP is in Istanbul?
If it's because we don't transact in TKL, can we change the default to USD for out of Aussie country and non-LE-covered IP address?"