### PR TITLE
WLT-214: added stripe_3ds for 4 WL brands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "4.10.20",
+  "version": "4.10.21",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -15,6 +15,7 @@ export const currencies: BrandCurrencies = {
     NZD: {
       paymentMethods: [
         "stripe",
+        "stripe_3ds",
       ],
     },
   },
@@ -23,6 +24,7 @@ export const currencies: BrandCurrencies = {
       paymentMethods: [
         "stripe",
         "braintree",
+        "stripe_3ds",
       ],
     },
   },
@@ -31,6 +33,7 @@ export const currencies: BrandCurrencies = {
       paymentMethods: [
         "stripe",
         "braintree",
+        "stripe_3ds",
       ],
     },
   },
@@ -72,6 +75,7 @@ export const currencies: BrandCurrencies = {
         "stripe",
         "braintree",
         "latitude_pay",
+        "stripe_3ds",
       ],
     },
   },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -192,6 +192,7 @@ describe("getPaymentMethodsByCurrencyCode()", function() {
       "stripe",
       "braintree",
       "latitude_pay",
+      "stripe_3ds",
     ]);
   });
 


### PR DESCRIPTION
https://aussiecommerce.atlassian.net/browse/WLT-214

added stripe_3ds for 4 below WL brands
cudotravel → AUD
dealstravel → AUD
treatmetravel → NZD
scoopontravel → AUD