### PR TITLE
WLT-214: 4.10.23 added stripe_3ds for 4 WL brands

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ import * as libRegions from '@luxuryescapes/lib-regions'
 ```
 
 ## publish
-1. Merge your branch
-2. Checkout master
+Now master branch is out-of-sync with the version used in www-le-customer repo, we created a branch of www-le-customer to reflect the version currently used in www-le-customer repo
+1. Merge your branch to www-le-customer branch
+2. Checkout www-le-customer
 3. Run `yarn publish`
+4. git tag {version you used in step 3}
+5. git push origin {version you used in step 3}
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "4.10.17",
+  "version": "4.10.23",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -15,6 +15,7 @@ export const currencies: BrandCurrencies = {
     NZD: {
       paymentMethods: [
         "stripe",
+        "stripe_3ds",
       ],
     },
   },
@@ -23,6 +24,7 @@ export const currencies: BrandCurrencies = {
       paymentMethods: [
         "stripe",
         "braintree",
+        "stripe_3ds",
       ],
     },
   },
@@ -31,6 +33,7 @@ export const currencies: BrandCurrencies = {
       paymentMethods: [
         "stripe",
         "braintree",
+        "stripe_3ds",
       ],
     },
   },
@@ -72,6 +75,7 @@ export const currencies: BrandCurrencies = {
         "stripe",
         "braintree",
         "latitude_pay",
+        "stripe_3ds",
       ],
     },
   },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -192,6 +192,7 @@ describe("getPaymentMethodsByCurrencyCode()", function() {
       "stripe",
       "braintree",
       "latitude_pay",
+      "stripe_3ds",
     ]);
   });
 


### PR DESCRIPTION
Because current master is no longer the same version used in www-le-customer (I don't know which other repo is using the master branch's lib-regions)

1 created www-le-customer branch to represent what's the version used in www-le-customer repo.
2 add changed from there, and merge back into www-le-customer
3 In future, we should use www-le-customer branch only for www-le-customer repo.

Below existing versions:

<img width="726" alt="Screen Shot 2022-07-20 at 9 15 22 am" src="https://user-images.githubusercontent.com/99770655/179863740-8b1e193f-96da-4ae3-8fcd-2064fdd42ca0.png">
