### PR TITLE
OPEX-686 update germany and treatme numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "4.10.23",
+  "version": "4.10.21",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "4.10.21",
+  "version": "4.10.24",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "4.10.21",
+  "version": "4.10.23",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "4.10.24",
+  "version": "4.10.22",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/regions.ts
+++ b/src/regions.ts
@@ -232,8 +232,8 @@ export const regions: BrandRegions = {
       flightsSupportEmail: DEFAULT_FLIGHTS_SUPPORT_EMAIL,
       phone: {
         local: {
-          humanReadable: "+61 2 9167 8207",
-          number: "+61291678207",
+          humanReadable: "0800 001 0786",
+          number: "08000010786",
         },
         international: {
           humanReadable: "+61 2 8320 6845",
@@ -1384,12 +1384,12 @@ export const regions: BrandRegions = {
       flightsSupportEmail: DEFAULT_FLIGHTS_SUPPORT_EMAIL,
       phone: {
         local: {
-          humanReadable: "09 222 4643",
-          number: "092224643",
+          humanReadable: "0800 846 182",
+          number: "0800846182",
         },
         international: {
-          humanReadable: "+64 9 222 4643",
-          number: "+6492224643",
+          humanReadable: "+61 3 7032 3413",
+          number: "+61370323413",
         },
         default: "international",
       },


### PR DESCRIPTION
[Ticket](https://aussiecommerce.atlassian.net/browse/OPEX-686?focusedCommentId=112137&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-112137)

Update Germany Sales & Support number from +61 2 9167 8207 → 0800 001 0786

Update [TreatMe](https://treatme.co.nz/nz) phone numbers as follows:
   * Sales & Support 0800 846 182
   * International Support Centre +61 3 7032 3413