### PR TITLE
Update readme and current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ import * as libRegions from '@luxuryescapes/lib-regions'
 ```
 
 ## Publish after your changes
-1. Merge your branch - including a bump to `version` in `package.json` (a separate PR is acceptable)
+1. Merge your branch - do NOT yet bump `version` in `package.json` (a separate PR is acceptable)
 2. Checkout master and pull down your changes
 3. (Run `yarn install`)
 4. Run `yarn publish`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ import * as libRegions from '@luxuryescapes/lib-regions'
 ```
 
 ## Publish after your changes
-1. Merge your branch - do NOT yet bump `version` in `package.json` (a separate PR is acceptable)
+1. Merge your branch - do NOT yet bump `version` in `package.json`
 2. Checkout master and pull down your changes
 3. (Run `yarn install`)
 4. Run `yarn publish`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "4.10.25",
+  "version": "4.10.26",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
Basically if you bump the version in package.json in your initial PR and follow the rest of the readme you will always bump the version by 2. I've had this happen a few times so I'm changing the readme.