### PR TITLE
MP-1386 fix getPaymentMethodsByCurrencyCode

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -240,6 +240,9 @@ describe("getPaymentMethodsByCurrencyCode()", function() {
       "atome_bp",
     ]);
   });
+  it("should return an empty array of payment methods when brand doesn't have sellected currency", function() {
+    expect(regionModule.getPaymentMethodsByCurrencyCode("AUD", "treatmetravel")).to.deep.equal([]);
+  });
 
   it("should return an array of payment methods default brand to luxuryescapes IN", function() {
     expect(regionModule.getPaymentMethodsByCurrencyCode("INR")).to.deep.equal([

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,8 +78,8 @@ export function getCurrencyCodes(brand?: string) {
 }
 
 export function getPaymentMethodsByCurrencyCode(currencyCode: string, brand?: string) {
-  if(!currencies(brand)[currencyCode]){
-    return []
+  if (!currencies(brand)[currencyCode]) {
+    return [];
   }
 
   return currencies(brand)[currencyCode].paymentMethods;

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,10 @@ export function getCurrencyCodes(brand?: string) {
 }
 
 export function getPaymentMethodsByCurrencyCode(currencyCode: string, brand?: string) {
+  if(!currencies(brand)[currencyCode]){
+    return []
+  }
+
   return currencies(brand)[currencyCode].paymentMethods;
 }
 


### PR DESCRIPTION
getPaymentMethodsByCurrencyCode function is failing when brand is asked to return all payment method for currency it doesn't have