### PR TITLE
WLT-416 Add Gift card option for Whitelabelled sites

### DIFF
--- a/src/regions.ts
+++ b/src/regions.ts
@@ -1374,7 +1374,20 @@ export const regions: BrandRegions = {
       referralAmount: 50,
       insuranceProductName: "insurance",
       referralMinSpendAmount: 499,
-      offerUrgencyTag: null,
+      offerUrgencyTag: {
+        tour: {
+          popular: {
+            min: 2,
+            period: 24,
+          },
+        },
+        hotel: {
+          popular: {
+            min: 4,
+            period: 24,
+          },
+        },
+      },
       giftCardOptions: [20, 50, 100, 250, 500, 1000],
     },
   ],
@@ -1404,7 +1417,20 @@ export const regions: BrandRegions = {
       referralAmount: 50,
       insuranceProductName: "insurance",
       referralMinSpendAmount: 499,
-      offerUrgencyTag: null,
+      offerUrgencyTag: {
+        tour: {
+          popular: {
+            min: 2,
+            period: 24,
+          },
+        },
+        hotel: {
+          popular: {
+            min: 4,
+            period: 24,
+          },
+        },
+      },
       giftCardOptions: [20, 50, 100, 250, 500, 1000],
     },
   ],
@@ -1434,7 +1460,20 @@ export const regions: BrandRegions = {
       referralAmount: 50,
       insuranceProductName: "insurance",
       referralMinSpendAmount: 499,
-      offerUrgencyTag: null,
+      offerUrgencyTag: {
+        tour: {
+          popular: {
+            min: 2,
+            period: 24,
+          },
+        },
+        hotel: {
+          popular: {
+            min: 4,
+            period: 24,
+          },
+        },
+      },
       giftCardOptions: [20, 50, 100, 250, 500, 1000],
     },
   ],
@@ -1465,7 +1504,20 @@ export const regions: BrandRegions = {
       referralAmount: 50,
       insuranceProductName: "protection",
       referralMinSpendAmount: 499,
-      offerUrgencyTag: null,
+      offerUrgencyTag: {
+        tour: {
+          popular: {
+            min: 2,
+            period: 24,
+          },
+        },
+        hotel: {
+          popular: {
+            min: 4,
+            period: 24,
+          },
+        },
+      },
       giftCardOptions: [20, 50, 100, 250, 500, 1000],
     },
   ],
@@ -1495,7 +1547,20 @@ export const regions: BrandRegions = {
       referralAmount: 50,
       insuranceProductName: "insurance",
       referralMinSpendAmount: 499,
-      offerUrgencyTag: null,
+      offerUrgencyTag: {
+        tour: {
+          popular: {
+            min: 2,
+            period: 24,
+          },
+        },
+        hotel: {
+          popular: {
+            min: 4,
+            period: 24,
+          },
+        },
+      },
       giftCardOptions: [20, 50, 100, 250, 500, 1000],
     },
   ],

--- a/src/regions.ts
+++ b/src/regions.ts
@@ -1375,6 +1375,7 @@ export const regions: BrandRegions = {
       insuranceProductName: "insurance",
       referralMinSpendAmount: 499,
       offerUrgencyTag: null,
+      giftCardOptions: [20, 50, 100, 250, 500, 1000],
     },
   ],
   kogantravel: [
@@ -1404,6 +1405,7 @@ export const regions: BrandRegions = {
       insuranceProductName: "insurance",
       referralMinSpendAmount: 499,
       offerUrgencyTag: null,
+      giftCardOptions: [20, 50, 100, 250, 500, 1000],
     },
   ],
   cudotravel: [
@@ -1433,6 +1435,7 @@ export const regions: BrandRegions = {
       insuranceProductName: "insurance",
       referralMinSpendAmount: 499,
       offerUrgencyTag: null,
+      giftCardOptions: [20, 50, 100, 250, 500, 1000],
     },
   ],
   treatmetravel: [
@@ -1463,6 +1466,7 @@ export const regions: BrandRegions = {
       insuranceProductName: "protection",
       referralMinSpendAmount: 499,
       offerUrgencyTag: null,
+      giftCardOptions: [20, 50, 100, 250, 500, 1000],
     },
   ],
   dealstravel: [
@@ -1492,6 +1496,7 @@ export const regions: BrandRegions = {
       insuranceProductName: "insurance",
       referralMinSpendAmount: 499,
       offerUrgencyTag: null,
+      giftCardOptions: [20, 50, 100, 250, 500, 1000],
     },
   ],
   cudo: [


### PR DESCRIPTION
### Description
The following changes are implemented:
1. Add [20, 50, 100, 250, 500, 1000] gift card options for WL sites
2. Unrelated change: Add urgency tags to WLs for the best seller tag to start showing up on the websites.

P.S: As is required, a version bump PR will soon follow this PR.