### PR TITLE
WLT-612 Remove latitude pay from WLs

### DIFF
--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -77,7 +77,6 @@ export const currencies: BrandCurrencies = {
       paymentMethods: [
         "stripe",
         "braintree",
-        "latitude_pay",
         "stripe_3ds",
         "giftcard",
       ],
@@ -88,7 +87,6 @@ export const currencies: BrandCurrencies = {
       paymentMethods: [
         "stripe",
         "braintree",
-        "latitude_pay",
         "stripe_3ds",
         "giftcard",
       ],

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -194,14 +194,12 @@ describe("getPaymentMethodsByCurrencyCode()", function() {
     expect(regionModule.getPaymentMethodsByCurrencyCode("AUD", "scoopontravel")).to.deep.equal([
       "stripe",
       "braintree",
-      "latitude_pay",
       "stripe_3ds",
       "giftcard",
     ]);
     expect(regionModule.getPaymentMethodsByCurrencyCode("AUD", "kogantravel")).to.deep.equal([
       "stripe",
       "braintree",
-      "latitude_pay",
       "stripe_3ds",
       "giftcard",
     ]);


### PR DESCRIPTION
### Description
Some WLs like Scoopontravel and Kogantravel have Latitude as payment method. This is not yet supported and should not be part of the config.