### PR TITLE
PP-969: Disable Latitude Pay for all portals

### DIFF
--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -106,7 +106,6 @@ export const currencies: BrandCurrencies = {
       paymentMethods: [
         "stripe",
         "braintree",
-        "latitude_pay",
       ],
     },
     NZD: {
@@ -126,7 +125,6 @@ export const currencies: BrandCurrencies = {
         "qantas",
         "latitude",
         "latitude_gem",
-        "latitude_pay",
         "giftcard",
         "klarna",
         "bridgerpay",
@@ -440,7 +438,6 @@ export const currencies: BrandCurrencies = {
           "qantas",
           "latitude",
           "latitude_gem",
-          "latitude_pay",
           "giftcard",
           "klarna",
           "bridgerpay",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -218,7 +218,6 @@ describe("getPaymentMethodsByCurrencyCode()", function() {
       "qantas",
       "latitude",
       "latitude_gem",
-      "latitude_pay",
       "giftcard",
       "klarna",
       "bridgerpay",


### PR DESCRIPTION
https://aussiecommerce.atlassian.net/browse/PP-969

We're disabling Latitude Pay because they're closing their business.
More details in the ticket.