### PR TITLE
Bump up to version 4.10.47

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "4.10.45",
+  "version": "4.10.47",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "4.10.44",
+  "version": "4.10.45",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
This new version was published to remove Latitude Pay as a a payment option from all portals.
This is due to Latitude Pay closing their business.
More details in ticket:
https://aussiecommerce.atlassian.net/browse/PP-969
