### PR TITLE
WLT-679 Get valid dynamic tags 

### DIFF
--- a/src/dynamicTags.ts
+++ b/src/dynamicTags.ts
@@ -9,11 +9,22 @@ const BRANDS = [
   "dealstravel",
 ];
 
+export enum PermittedTags {
+  "BrandName" = "BrandName",
+  "SalesEmail" = "SalesEmail",
+  "CruiseEmail" = "CruiseEmail",
+  "TourEmail" = "TourEmail",
+  "TrustedPartnerTourEmail" = "TrustedPartnerTourEmail",
+  "FlightPolicyLink" = "FlightPolicyLink"
+};
+
+type PermittedTagsType = keyof typeof PermittedTags;
+
 type Brand = typeof BRANDS[number];
 
-export interface Tags {
-  [tag: string]: string;
-}
+export type Tags = {
+  [key in PermittedTagsType]: string;
+};
 
 type BrandTags = {
   [brand in Brand]: Tags;

--- a/src/dynamicTags.ts
+++ b/src/dynamicTags.ts
@@ -15,8 +15,8 @@ export enum PermittedTags {
   "CruiseEmail" = "CruiseEmail",
   "TourEmail" = "TourEmail",
   "TrustedPartnerTourEmail" = "TrustedPartnerTourEmail",
-  "FlightPolicyLink" = "FlightPolicyLink"
-};
+  "FlightPolicyLink" = "FlightPolicyLink",
+}
 
 type PermittedTagsType = keyof typeof PermittedTags;
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import * as regionModule from "./";
 import { Brand } from "./regions";
+import { PermittedTags } from './dynamicTags';
 
 describe("getRegionCodes()", function() {
   it("should return an array of region codes", function() {
@@ -194,13 +195,19 @@ describe("getCurrencyCodes()", function() {
 });
 
 describe("getDynamicTagsForBrand()", function () {
-  it.only("should return an dynamic tags for brands", function () {
+  it("should return an dynamic tags for brands", function () {
     // Spot check few parameters for a few brands
     expect(regionModule.getDynamicTagsForBrand("scoopontravel")).to.have.property("BrandName", "Scoopon");
     expect(regionModule.getDynamicTagsForBrand("kogantravel")).to.have.property("SalesEmail", "sales@kogantravel.com");
     expect(regionModule.getDynamicTagsForBrand("leforwork")).to.have.property("BrandName", "LE for Business");
     //Defaulted to LE when no brand is passed
     expect(regionModule.getDynamicTagsForBrand()).to.have.property("BrandName", "Luxury Escapes");
+  });
+});
+
+describe("getValidDynamicTags()", function () {
+  it("should return list of valid dynamic tags", function () {
+    expect(regionModule.getValidDynamicTags()).to.deep.equal(Object.values(PermittedTags))
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { currencies as _currencies } from "./currencies";
-import { dynamicTags as _dynamicTags, Tags, PermittedTags } from "./dynamicTags";
+import { dynamicTags as _dynamicTags, PermittedTags, Tags } from "./dynamicTags";
 import { ExtendedRegion as Region, extendedRegions } from "./extended";
 import { priorityPhoneNumbers } from "./priorityPhoneNumbers";
 import { Brand, LUXURY_ESCAPES } from "./regions";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { currencies as _currencies } from "./currencies";
-import { dynamicTags as _dynamicTags, Tags } from "./dynamicTags";
+import { dynamicTags as _dynamicTags, Tags, PermittedTags } from "./dynamicTags";
 import { ExtendedRegion as Region, extendedRegions } from "./extended";
 import { priorityPhoneNumbers } from "./priorityPhoneNumbers";
 import { Brand, LUXURY_ESCAPES } from "./regions";
@@ -93,6 +93,10 @@ export function getCurrencyCodes(brand?: string) {
 
 export function getDynamicTagsForBrand(brand?: Brand): Tags {
   return dynamicTagsForBrand(brand);
+}
+
+export function getValidDynamicTags(): string[] {
+  return Object.keys(PermittedTags);
 }
 
 export function getPaymentMethodsByCurrencyCode(currencyCode: string, brand?: string) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,10 +4,14 @@
     "rootDir": "./src",
     "target": "es5",
     "declaration": true,
-    "lib": ["dom", "es7"],
+    "lib": [
+      "dom",
+      "es7",
+      "es2017"
+    ],
     "module": "commonjs",
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
   },
   "exclude": [
     "*/**.test.ts"


### PR DESCRIPTION
### Description
For dynamic tags to be validated, it is essential to get a list of dynamic tags that can be added to any content. In order to do so, I have added an enum defining the various tags that will be supported currently. This will help us to validate in offer service, whether the dynamic tag added by Content editors is valid/invalid. We would avoid pitfalls with typos and ensure production does not see these dynamic tags appearing without being replaced due to silly mistakes.

More on Dynamic tags - read [ADR](https://aussiecommerce.atlassian.net/wiki/spaces/TEC/pages/2459992149/2023-02+-+Allow+dynamic+tags+in+offer+content+fields+and+replace+tag+with+brand+specific+data+before+showing+to+End+User.)