### PR TITLE
[OPEX-928] update base support priority number

### DIFF
--- a/src/priorityPhoneNumbers.ts
+++ b/src/priorityPhoneNumbers.ts
@@ -29,12 +29,12 @@ export const priorityPhoneNumbers: BrandPriorityPhoneNumber = {
       phonePrefix: "61",
       phone: {
         local: {
-          humanReadable: "1300 86 04 54",
-          number: "1300860454",
+          humanReadable: "1300 701 198",
+          number: "1300701198",
         },
         international: {
-          humanReadable: "+61 3 8593 4859",
-          number: "+61385934859",
+          humanReadable: "+61 3 7032 3381",
+          number: "+61370323381",
         },
         default: "international",
       },


### PR DESCRIPTION
This number will be used as default, for the cases where it is not tour, cruise, ultralux or expensive packages offer.
Previous number was reassigned to ultralux.