### PR TITLE
WLT-679 Add a function to get supported brands for dynamic tags. 

### DIFF
--- a/src/dynamicTags.ts
+++ b/src/dynamicTags.ts
@@ -1,4 +1,4 @@
-const BRANDS = [
+export const DYNAMIC_TAG_BRANDS = [
   "luxuryescapes",
   "scooponexperience",
   "scoopontravel",
@@ -20,7 +20,7 @@ export enum PermittedTags {
 
 type PermittedTagsType = keyof typeof PermittedTags;
 
-type Brand = typeof BRANDS[number];
+type Brand = typeof DYNAMIC_TAG_BRANDS[number];
 
 export type Tags = {
   [key in PermittedTagsType]: string;

--- a/src/dynamicTags.ts
+++ b/src/dynamicTags.ts
@@ -1,3 +1,7 @@
+// When dynamic tags are modified or brands are added DYNAMIC_TAG_BRANDS list, remember
+// to publish a new lib-regions npm version and include that version number in
+// svc-offer and svc-public offer service.
+
 export const DYNAMIC_TAG_BRANDS = [
   "luxuryescapes",
   "scooponexperience",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import * as regionModule from "./";
 import { Brand } from "./regions";
-import { PermittedTags } from './dynamicTags';
+import { PermittedTags, DYNAMIC_TAG_BRANDS } from './dynamicTags';
 
 describe("getRegionCodes()", function() {
   it("should return an array of region codes", function() {
@@ -208,6 +208,12 @@ describe("getDynamicTagsForBrand()", function () {
 describe("getValidDynamicTags()", function () {
   it("should return list of valid dynamic tags", function () {
     expect(regionModule.getValidDynamicTags()).to.deep.equal(Object.values(PermittedTags))
+  });
+});
+
+describe("getAllBrandsThatSupportDynamicTags()", function () {
+  it("should return list of valid brands that support dynamic tags", function () {
+    expect(regionModule.getAllBrandsThatSupportDynamicTags()).to.deep.equal(DYNAMIC_TAG_BRANDS)
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { currencies as _currencies } from "./currencies";
-import { dynamicTags as _dynamicTags, PermittedTags, Tags } from "./dynamicTags";
+import { DYNAMIC_TAG_BRANDS, dynamicTags as _dynamicTags, PermittedTags, Tags } from "./dynamicTags";
 import { ExtendedRegion as Region, extendedRegions } from "./extended";
 import { priorityPhoneNumbers } from "./priorityPhoneNumbers";
 import { Brand, LUXURY_ESCAPES } from "./regions";
@@ -97,6 +97,10 @@ export function getDynamicTagsForBrand(brand?: Brand): Tags {
 
 export function getValidDynamicTags(): string[] {
   return Object.keys(PermittedTags);
+}
+
+export function getAllBrandsThatSupportDynamicTags(): string[] {
+  return DYNAMIC_TAG_BRANDS;
 }
 
 export function getPaymentMethodsByCurrencyCode(currencyCode: string, brand?: string) {


### PR DESCRIPTION
### Description
This is in context of dynamic tags. In order to address a [review comment](https://github.com/lux-group/svc-offer/pull/1175#discussion_r1155410287) added in Offer service PR, where we declared a constant to store the brands that support dynamic tags. Instead of using constants in offer service and public offer service, we must fetch the brands that support dynamic tags from lib-regions by using the newly added function `getValidBrandsForDynamicTags`. 

This will be used during dynamic tag replacement in Offer and public offer service.

Test case has been added for the function.