### PR TITLE
WLT-679 Remove `scooponexperience` from dynamic tags brand list

### DIFF
--- a/src/dynamicTags.ts
+++ b/src/dynamicTags.ts
@@ -4,7 +4,6 @@
 
 export const DYNAMIC_TAG_BRANDS = [
   "luxuryescapes",
-  "scooponexperience",
   "scoopontravel",
   "kogantravel",
   "lebusinesstraveller",


### PR DESCRIPTION
### Description
Remove `scooponexperience` from dynamic tags brand list as it is not a brand that supports dynamic tags. Scoopontravel is already in the list.