### PR TITLE
EXP-1510: add deprecation for all logics about dynamic tags

### DIFF
--- a/src/dynamicTags.ts
+++ b/src/dynamicTags.ts
@@ -1,9 +1,9 @@
-/** 
+  /*
  * @deprecated use from lib-global instead
- * 
+ *
  * This logic was moved to lib-global
- * 
- * */
+ *
+ **/
 
 // When dynamic tags are modified or brands are added DYNAMIC_TAG_BRANDS list, remember
 // to publish a new lib-regions npm version and include that version number in

--- a/src/dynamicTags.ts
+++ b/src/dynamicTags.ts
@@ -1,3 +1,10 @@
+/** 
+ * @deprecated use from lib-global instead
+ * 
+ * This logic was moved to lib-global
+ * 
+ * */
+
 // When dynamic tags are modified or brands are added DYNAMIC_TAG_BRANDS list, remember
 // to publish a new lib-regions npm version and include that version number in
 // svc-offer and svc-public offer service.

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ function currencies(brand?: string) {
   return _currencies[brand || LUXURY_ESCAPES];
 }
 
+/** @deprecated use from lib-global instead */
 function dynamicTagsForBrand(brand?: Brand): Tags {
   return _dynamicTags[brand || LUXURY_ESCAPES];
 }
@@ -91,14 +92,17 @@ export function getCurrencyCodes(brand?: string) {
   return Object.keys(currencies(brand));
 }
 
+/** @deprecated use from lib-global instead */
 export function getDynamicTagsForBrand(brand?: Brand): Tags {
   return dynamicTagsForBrand(brand);
 }
 
+/** @deprecated use from lib-global instead */
 export function getValidDynamicTags(): string[] {
   return Object.keys(PermittedTags);
 }
 
+/** @deprecated use from lib-global instead */
 export function getAllBrandsThatSupportDynamicTags(): string[] {
   return DYNAMIC_TAG_BRANDS;
 }


### PR DESCRIPTION
[EXP-1510](https://aussiecommerce.atlassian.net/browse/EXP-1510)

## Related PR's
[lib-global](https://github.com/lux-group/lib-global/pull/92)

## Content
Just add deprecation for dynamic tags logics because it was moved to lib-global.

For more information, please check the [lib-global PR](https://github.com/lux-group/lib-global/pull/92).

The intention is to remove this logic from here once svc-offer and svc-public-offer start using the lib-global.



[EXP-1510]: https://aussiecommerce.atlassian.net/browse/EXP-1510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ