### PR TITLE
LEB-327 remove braintree from list of payment providers for lebussinestraveller

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "4.10.64",
+  "version": "4.10.65",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -100,7 +100,6 @@ export const currencies: BrandCurrencies = {
     AUD: {
       paymentMethods: [
         "stripe",
-        "braintree",
         "stripe_3ds",
       ],
     },


### PR DESCRIPTION
![image](https://github.com/lux-group/lib-regions/assets/107819446/e9ea4f67-4e60-4744-9bae-82984568c756)

as you can see, with this latest version, paypal doesn't come up