### PR TITLE
Add stripe payment element to 'DE' region

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { currencies as _currencies } from "./currencies";
 import { ExtendedRegion as Region, extendedRegions } from "./extended";
+import { paymentMethodsByRegion } from "./paymentMethodsByregion";
 import { priorityPhoneNumbers } from "./priorityPhoneNumbers";
 import { Brand, LUXURY_ESCAPES } from "./regions";
 
@@ -92,6 +93,11 @@ export function getPaymentMethodsByCurrencyCode(currencyCode: string, brand?: st
   }
 
   return currencies(brand)[currencyCode].paymentMethods;
+}
+
+export function getPaymentMethodsByRegion(regionCode: string) : string[] {
+  const paymentMethodsByRegionMap = paymentMethodsByRegion
+  return paymentMethodsByRegionMap[regionCode] || []
 }
 
 export function getZeroDecimalCurrencies() {

--- a/src/paymentMethodsByregion.ts
+++ b/src/paymentMethodsByregion.ts
@@ -1,0 +1,13 @@
+// This map will only include payment methods which are to be added for a particular region only
+// and not for all regions with a particular currency. If a payment method is to be switched on for
+// all regions for the currency (i.e. currencywide) add the payment method in currencies.ts instead
+
+type PaymentMethodsByRegion = {
+    [key:string]: string[] 
+}
+
+export const paymentMethodsByRegion : PaymentMethodsByRegion = {
+    'DE':[
+        'stripe_payment_element_card'
+    ],
+}


### PR DESCRIPTION
https://aussiecommerce.atlassian.net/browse/PP-1247
This change adds the payment element to 'DE' (Germany) region and adds functionality to get payment methods by region.