### PR TITLE
Add go cardless payment method for AUD and LE

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -136,6 +136,7 @@ export const currencies: BrandCurrencies = {
         "waave_bp",
         "latitude_gem",
         "velocity",
+        "gocardless",
       ],
     },
     CAD: {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -238,6 +238,7 @@ describe("getPaymentMethodsByCurrencyCode()", function() {
       "waave_bp",
       "latitude_gem",
       "velocity",
+      "gocardless",
     ]);
   });
 


### PR DESCRIPTION
A new payment methods has been made available for LE in AUD (go cardless, AKA PayTo), this PR adds that new method.