### PR TITLE
[CRO-2788] Sort offer list regions by business key regions

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,11 +2,40 @@ import { expect } from "chai";
 import * as regionModule from "./";
 import { Brand } from "./regions";
 
-describe("getRegionCodes()", function() {
-  it("should return an array of region codes", function() {
+describe("getRegionCodes()", function () {
+  it("should return an array of region codes", function () {
     expect(regionModule.getRegionCodes("scoopontravel")).to.deep.equal(["AU"]);
     expect(regionModule.getRegionCodes("kogantravel")).to.deep.equal(["AU"]);
-    expect(regionModule.getRegionCodes("lebusinesstraveller")).to.deep.equal(["AU"]);
+    expect(regionModule.getRegionCodes("lebusinesstraveller")).to.deep.equal([
+      "AU",
+    ]);
+  });
+});
+
+describe("getRegionCodesSortedByKeyRegions", () => {
+  const { allRegionCodes, lastKeyRegionIndex } =
+    regionModule.getRegionCodesSortedByKeyRegions();
+
+  it("should return key region codes sorted and as initial elements", () => {
+    const keyRegionCodes = allRegionCodes.slice(0, 5);
+    expect(keyRegionCodes).to.deep.equal(["AU", "US", "GB", "NZ", "SG"]);
+  });
+
+  it("should return the index of last key region", () => {
+    expect(lastKeyRegionIndex).to.be.equal(4);
+  });
+
+  it("should return other region codes sorted and after key region codes", () => {
+    const otherRegionCodes = allRegionCodes.slice(5, 10);
+    expect(otherRegionCodes).to.deep.equal(["CA", "CN", "FR", "DE", "HK"]);
+  });
+
+  it("should not return excluded regions", () => {
+    const { allRegionCodes } = regionModule.getRegionCodesSortedByKeyRegions(
+      "scoopontravel",
+      ["AU"]
+    );
+    expect(allRegionCodes).to.deep.equal([]);
   });
 });
 
@@ -43,26 +72,26 @@ const expectedLeRegions = [
   "Vietnam",
 ];
 
-describe("getRegionNames()", function() {
+describe("getRegionNames()", function () {
   const cases: [Brand, string[]][] = [
-    ['luxuryescapes', expectedLeRegions],
-    ['scoopontravel', ['Australia']],
-    ['cudotravel', ['Australia']],
-    ['treatmetravel', ['New Zealand']],
-    ['dealstravel', ['Australia']],
-    ['kogantravel', ['Australia']],
-    ['yidu', ['China']],
-    ['zoomzoom', ['Korea', 'Australia']],
-    ['newwhitelabel', ['Australia']],
-    ['lebusinesstraveller', ['Australia']],
+    ["luxuryescapes", expectedLeRegions],
+    ["scoopontravel", ["Australia"]],
+    ["cudotravel", ["Australia"]],
+    ["treatmetravel", ["New Zealand"]],
+    ["dealstravel", ["Australia"]],
+    ["kogantravel", ["Australia"]],
+    ["yidu", ["China"]],
+    ["zoomzoom", ["Korea", "Australia"]],
+    ["newwhitelabel", ["Australia"]],
+    ["lebusinesstraveller", ["Australia"]],
   ];
   cases.forEach(([brand, expectedRegions]) => {
     it(`when the brand "${brand}" is passed as an argument to getRegionNames(brand), the function should return ${expectedRegions}`, () => {
       expect(regionModule.getRegionNames(brand)).to.deep.equal(expectedRegions);
-    })
-  })
+    });
+  });
 
-  it("should return an array of region names default brand to luxuryescapes", function() {
+  it("should return an array of region names default brand to luxuryescapes", function () {
     expect(regionModule.getRegionNames()).to.deep.equal([
       "Australia",
       "Canada",
@@ -98,71 +127,83 @@ describe("getRegionNames()", function() {
   });
 });
 
-describe("getRegionByCode()", function() {
-  it("should return null in brand without region", function() {
+describe("getRegionByCode()", function () {
+  it("should return null in brand without region", function () {
     expect(regionModule.getRegionByCode("CA", "scoopontravel")).to.be.undefined;
   });
 });
 
-describe("getRegionByCurrency()", function() {
-  it("should return region from currency code", function() {
-    const region = regionModule.getRegionByCurrency("AUD", "luxuryescapes")
-    expect(region ? region.code : 'fail test if region undefined').to.equal("AU");
+describe("getRegionByCurrency()", function () {
+  it("should return region from currency code", function () {
+    const region = regionModule.getRegionByCurrency("AUD", "luxuryescapes");
+    expect(region ? region.code : "fail test if region undefined").to.equal(
+      "AU"
+    );
   });
 });
 
-describe("getRegionNameByCode()", function() {
-  it("returns region name if region exists", function() {
-    expect(regionModule.getRegionNameByCode("AU", "scoopontravel")).to.equal("Australia");
+describe("getRegionNameByCode()", function () {
+  it("returns region name if region exists", function () {
+    expect(regionModule.getRegionNameByCode("AU", "scoopontravel")).to.equal(
+      "Australia"
+    );
   });
 
-  it("returns 'null' code if region is absent for brand", function() {
-    expect(regionModule.getRegionNameByCode("CA", "scoopontravel")).to.equal(null);
+  it("returns 'null' code if region is absent for brand", function () {
+    expect(regionModule.getRegionNameByCode("CA", "scoopontravel")).to.equal(
+      null
+    );
   });
 
-  it("returns region name if region exists default brand to luxuryescapes", function() {
+  it("returns region name if region exists default brand to luxuryescapes", function () {
     expect(regionModule.getRegionNameByCode("AU")).to.equal("Australia");
   });
 });
 
-describe("getDefaultRegion()", function() {
-  it("should return the default region's info", function() {
+describe("getDefaultRegion()", function () {
+  it("should return the default region's info", function () {
     expect(regionModule.getDefaultRegion("treatmetravel").code).to.equal("NZ");
   });
 });
 
-describe("getDefaultRegionCode()", function() {
-  it("should return the default region's code", function() {
+describe("getDefaultRegionCode()", function () {
+  it("should return the default region's code", function () {
     expect(regionModule.getDefaultRegionCode("luxuryescapes")).to.equal("AU");
   });
 
-  it("should return the default region's code default brand to luxuryescapes", function() {
+  it("should return the default region's code default brand to luxuryescapes", function () {
     expect(regionModule.getDefaultRegionCode()).to.equal("AU");
   });
 
-  it("should return the default region for the brand", function() {
+  it("should return the default region for the brand", function () {
     expect(regionModule.getDefaultRegionCode("treatmetravel")).to.equal("NZ");
   });
 });
 
-describe("getDefaultRegionName()", function() {
-  it("should return the default region's name", function() {
-    expect(regionModule.getDefaultRegionName("scoopontravel")).to.equal("Australia");
+describe("getDefaultRegionName()", function () {
+  it("should return the default region's name", function () {
+    expect(regionModule.getDefaultRegionName("scoopontravel")).to.equal(
+      "Australia"
+    );
   });
 
-  it("should return the default region's name default brand to luxuryescapes", function() {
+  it("should return the default region's name default brand to luxuryescapes", function () {
     expect(regionModule.getDefaultRegionName()).to.equal("Australia");
   });
 });
 
-describe("getCurrencyCodes()", function() {
-  it("should return an array of currency codes", function() {
-    expect(regionModule.getCurrencyCodes("scoopontravel")).to.deep.equal(["AUD"]);
+describe("getCurrencyCodes()", function () {
+  it("should return an array of currency codes", function () {
+    expect(regionModule.getCurrencyCodes("scoopontravel")).to.deep.equal([
+      "AUD",
+    ]);
     expect(regionModule.getCurrencyCodes("kogantravel")).to.deep.equal(["AUD"]);
-    expect(regionModule.getCurrencyCodes("lebusinesstraveller")).to.deep.equal(["AUD"]);
+    expect(regionModule.getCurrencyCodes("lebusinesstraveller")).to.deep.equal([
+      "AUD",
+    ]);
   });
 
-  it("should return an array of currency codes default brand to luxuryescapes", function() {
+  it("should return an array of currency codes default brand to luxuryescapes", function () {
     expect(regionModule.getCurrencyCodes()).to.deep.equal([
       "AUD",
       "CAD",
@@ -193,23 +234,17 @@ describe("getCurrencyCodes()", function() {
   });
 });
 
-describe("getPaymentMethodsByCurrencyCode()", function() {
-  it("should return an array of payment methods", function() {
-    expect(regionModule.getPaymentMethodsByCurrencyCode("AUD", "scoopontravel")).to.deep.equal([
-      "stripe",
-      "braintree",
-      "stripe_3ds",
-      "giftcard",
-    ]);
-    expect(regionModule.getPaymentMethodsByCurrencyCode("AUD", "kogantravel")).to.deep.equal([
-      "stripe",
-      "braintree",
-      "stripe_3ds",
-      "giftcard",
-    ]);
+describe("getPaymentMethodsByCurrencyCode()", function () {
+  it("should return an array of payment methods", function () {
+    expect(
+      regionModule.getPaymentMethodsByCurrencyCode("AUD", "scoopontravel")
+    ).to.deep.equal(["stripe", "braintree", "stripe_3ds", "giftcard"]);
+    expect(
+      regionModule.getPaymentMethodsByCurrencyCode("AUD", "kogantravel")
+    ).to.deep.equal(["stripe", "braintree", "stripe_3ds", "giftcard"]);
   });
 
-  it("should return an array of payment methods default brand to luxuryescapes", function() {
+  it("should return an array of payment methods default brand to luxuryescapes", function () {
     expect(regionModule.getPaymentMethodsByCurrencyCode("AUD")).to.deep.equal([
       "le_credit",
       "stripe",
@@ -227,7 +262,7 @@ describe("getPaymentMethodsByCurrencyCode()", function() {
     ]);
   });
 
-  it("should return an array of payment methods default brand to luxuryescapes SGD", function() {
+  it("should return an array of payment methods default brand to luxuryescapes SGD", function () {
     expect(regionModule.getPaymentMethodsByCurrencyCode("SGD")).to.deep.equal([
       "le_credit",
       "stripe",
@@ -241,35 +276,39 @@ describe("getPaymentMethodsByCurrencyCode()", function() {
       "atome_bp",
     ]);
   });
-  it("should return an empty array of payment methods when brand doesn't have sellected currency", function() {
-    expect(regionModule.getPaymentMethodsByCurrencyCode("AUD", "treatmetravel")).to.deep.equal([]);
+  it("should return an empty array of payment methods when brand doesn't have sellected currency", function () {
+    expect(
+      regionModule.getPaymentMethodsByCurrencyCode("AUD", "treatmetravel")
+    ).to.deep.equal([]);
   });
 
-  it("should return an array of payment methods default brand to luxuryescapes IN", function() {
+  it("should return an array of payment methods default brand to luxuryescapes IN", function () {
     expect(regionModule.getPaymentMethodsByCurrencyCode("INR")).to.deep.equal([
       "le_credit",
-        "stripe",
-        "deposit_stripe",
-        "razorpay",
-        "giftcard",
-        "vistara",
-        "stripe_3ds",
+      "stripe",
+      "deposit_stripe",
+      "razorpay",
+      "giftcard",
+      "vistara",
+      "stripe_3ds",
     ]);
   });
 });
 
-describe("getZeroDecimalCurrencies()", function() {
-  it("should return an array of currency codes", function() {
+describe("getZeroDecimalCurrencies()", function () {
+  it("should return an array of currency codes", function () {
     expect(regionModule.getZeroDecimalCurrencies()).to.be.an("array");
   });
 });
 
-describe("getRegionLang()", function() {
-  it("should return an array of region langs", function() {
-    expect(regionModule.getRegionLang("scoopontravel")).to.deep.equal(["en-AU"]);
+describe("getRegionLang()", function () {
+  it("should return an array of region langs", function () {
+    expect(regionModule.getRegionLang("scoopontravel")).to.deep.equal([
+      "en-AU",
+    ]);
   });
 
-  it("should return an array of region langs default brand to luxuryescapes", function() {
+  it("should return an array of region langs default brand to luxuryescapes", function () {
     expect(regionModule.getRegionLang()).to.deep.equal([
       "en-AU",
       "en-CA",
@@ -305,30 +344,32 @@ describe("getRegionLang()", function() {
   });
 });
 
-describe("getRegionReferralAmountByCode()", function() {
-  it("should return the region referral amount", function() {
-    expect(regionModule.getRegionReferralAmountByCode("AU", "scoopontravel")).to.deep.equal(50);
+describe("getRegionReferralAmountByCode()", function () {
+  it("should return the region referral amount", function () {
+    expect(
+      regionModule.getRegionReferralAmountByCode("AU", "scoopontravel")
+    ).to.deep.equal(50);
   });
 
-  it("should return the region referral amount by default brand to luxuryescapes", function() {
+  it("should return the region referral amount by default brand to luxuryescapes", function () {
     expect(regionModule.getRegionReferralAmountByCode("CA")).to.deep.equal(50);
   });
 });
 
-describe("getRegionNamesAndCode()", function() {
-  it("should return an array of region names and code", function() {
+describe("getRegionNamesAndCode()", function () {
+  it("should return an array of region names and code", function () {
     expect(regionModule.getRegionNamesAndCode("scoopontravel")).to.deep.equal([
-      {name: "Australia", code: "AU"},
+      { name: "Australia", code: "AU" },
     ]);
   });
 });
 
-describe("isRegionAllowed()", function() {
-  it("should return true if brand has region", function() {
+describe("isRegionAllowed()", function () {
+  it("should return true if brand has region", function () {
     expect(regionModule.isRegionAllowed("luxuryescapes", "CA")).to.equal(true);
   });
 
-  it("should return true if brand has region", function() {
+  it("should return true if brand has region", function () {
     expect(regionModule.isRegionAllowed("scoopontravel", "NZ")).to.equal(false);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,9 +80,7 @@ export function getRegionCodesSortedByKeyRegions(
     ? getRegionCodes(brand).filter((code) => !excludedRegions.includes(code))
     : getRegionCodes(brand);
 
-  const keyRegions = Array.from(REGIONS_START_ORDER).filter((code) =>
-    codes.includes(code),
-  );
+  const keyRegions = REGIONS_START_ORDER.filter((code) => codes.includes(code));
   const otherRegions = codes.filter(
     (code) => !REGIONS_START_ORDER.includes(code),
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export function getPriorityPhoneNumbers(brand?: string) {
 
 export function getPriorityPhoneNumberByCode(
   regionCode: string,
-  brand?: string
+  brand?: string,
 ) {
   if (!regionCode) {
     return null;
@@ -50,7 +50,7 @@ export function getPriorityPhoneNumberByCode(
   if (priorityNumbers.length > 0) {
     const pNumber = priorityNumbers.find(
       (phoneNumber) =>
-        phoneNumber.code.toLowerCase() === regionCode.toLowerCase()
+        phoneNumber.code.toLowerCase() === regionCode.toLowerCase(),
     );
 
     return pNumber ? pNumber : null;
@@ -74,22 +74,25 @@ export function getRegionCodes(brand?: Brand) {
 // TODO: Implement avoid codes
 export function getRegionCodesSortedByKeyRegions(
   brand?: Brand,
-  excludedRegions?: string[]
+  excludedRegions?: string[],
 ) {
   const codes = excludedRegions
     ? getRegionCodes(brand).filter((code) => !excludedRegions.includes(code))
     : getRegionCodes(brand);
 
   const keyRegions = new Set<string>([]);
-  const otherRegions: Array<string> = [];
+  const otherRegions: string[] = [];
 
   for (const code of codes) {
-    if (REGIONS_START_ORDER.has(code)) keyRegions.add(code);
-    else otherRegions.push(code);
+    if (REGIONS_START_ORDER.has(code)) {
+      keyRegions.add(code);
+    } else {
+      otherRegions.push(code);
+    }
   }
 
   const sortedKeyRegions = Array.from(REGIONS_START_ORDER).filter((code) =>
-    keyRegions.has(code)
+    keyRegions.has(code),
   );
 
   return {
@@ -107,13 +110,13 @@ export function getRegionByCode(regionCode: string, brand?: Brand) {
     return null;
   }
   return regions(brand).find(
-    (region) => region.code.toLowerCase() === regionCode.toLowerCase()
+    (region) => region.code.toLowerCase() === regionCode.toLowerCase(),
   );
 }
 
 export function getRegionByCurrency(currencyCode: string, brand?: Brand) {
   return regions(brand).find(
-    (region) => region.currencyCode.toLowerCase() === currencyCode.toLowerCase()
+    (region) => region.currencyCode.toLowerCase() === currencyCode.toLowerCase(),
   );
 }
 
@@ -140,7 +143,7 @@ export function getCurrencyCodes(brand?: string) {
 
 export function getPaymentMethodsByCurrencyCode(
   currencyCode: string,
-  brand?: string
+  brand?: string,
 ) {
   if (!currencies(brand)[currencyCode]) {
     return [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export function getPriorityPhoneNumbers(brand?: string) {
 
 export function getPriorityPhoneNumberByCode(
   regionCode: string,
-  brand?: string
+  brand?: string,
 ) {
   if (!regionCode) {
     return null;
@@ -51,7 +51,7 @@ export function getPriorityPhoneNumberByCode(
   if (priorityNumbers.length > 0) {
     const pNumber = priorityNumbers.find(
       (phoneNumber) =>
-        phoneNumber.code.toLowerCase() === regionCode.toLowerCase()
+        phoneNumber.code.toLowerCase() === regionCode.toLowerCase(),
     );
 
     return pNumber ? pNumber : null;
@@ -74,17 +74,17 @@ export function getRegionCodes(brand?: Brand) {
 
 export function getRegionCodesSortedByKeyRegions(
   brand?: Brand,
-  excludedRegions?: string[]
+  excludedRegions?: string[],
 ) {
   const codes = excludedRegions
     ? getRegionCodes(brand).filter((code) => !excludedRegions.includes(code))
     : getRegionCodes(brand);
 
   const keyRegions = Array.from(REGIONS_START_ORDER).filter((code) =>
-    codes.includes(code)
+    codes.includes(code),
   );
   const otherRegions = codes.filter(
-    (code) => !REGIONS_START_ORDER.includes(code)
+    (code) => !REGIONS_START_ORDER.includes(code),
   );
 
   return {
@@ -102,13 +102,13 @@ export function getRegionByCode(regionCode: string, brand?: Brand) {
     return null;
   }
   return regions(brand).find(
-    (region) => region.code.toLowerCase() === regionCode.toLowerCase()
+    (region) => region.code.toLowerCase() === regionCode.toLowerCase(),
   );
 }
 
 export function getRegionByCurrency(currencyCode: string, brand?: Brand) {
   return regions(brand).find(
-    (region) => region.currencyCode.toLowerCase() === currencyCode.toLowerCase()
+    (region) => region.currencyCode.toLowerCase() === currencyCode.toLowerCase(),
   );
 }
 
@@ -135,7 +135,7 @@ export function getCurrencyCodes(brand?: string) {
 
 export function getPaymentMethodsByCurrencyCode(
   currencyCode: string,
-  brand?: string
+  brand?: string,
 ) {
   if (!currencies(brand)[currencyCode]) {
     return [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,23 +15,43 @@ function currencies(brand?: string) {
 }
 
 const zeroDecimalCurrencies = [
-  "BIF", "CLP", "DJF", "GNF", "JPY", "KMF", "KRW", "MGA",
-  "PYG", "RWF", "VND", "VUV", "XAF", "XOF", "XPF",
+  "BIF",
+  "CLP",
+  "DJF",
+  "GNF",
+  "JPY",
+  "KMF",
+  "KRW",
+  "MGA",
+  "PYG",
+  "RWF",
+  "VND",
+  "VUV",
+  "XAF",
+  "XOF",
+  "XPF",
 ];
+
+const REGIONS_START_ORDER = new Set(["AU", "US", "GB", "NZ", "SG"]);
 
 export function getPriorityPhoneNumbers(brand?: string) {
   return priorityPhoneNumbers[brand || LUXURY_ESCAPES];
 }
 
-export function getPriorityPhoneNumberByCode(regionCode: string, brand?: string) {
+export function getPriorityPhoneNumberByCode(
+  regionCode: string,
+  brand?: string
+) {
   if (!regionCode) {
     return null;
   }
 
   const priorityNumbers = getPriorityPhoneNumbers(brand);
   if (priorityNumbers.length > 0) {
-    const pNumber = priorityNumbers
-      .find((phoneNumber) => (phoneNumber.code.toLowerCase() === regionCode.toLowerCase()));
+    const pNumber = priorityNumbers.find(
+      (phoneNumber) =>
+        phoneNumber.code.toLowerCase() === regionCode.toLowerCase()
+    );
 
     return pNumber ? pNumber : null;
   }
@@ -51,6 +71,33 @@ export function getRegionCodes(brand?: Brand) {
   return regions(brand).map((region) => region.code);
 }
 
+// TODO: Implement avoid codes
+export function getRegionCodesSortedByKeyRegions(
+  brand?: Brand,
+  excludedRegions?: string[]
+) {
+  const codes = excludedRegions
+    ? getRegionCodes(brand).filter((code) => !excludedRegions.includes(code))
+    : getRegionCodes(brand);
+
+  const keyRegions = new Set<string>([]);
+  const otherRegions: Array<string> = [];
+
+  for (const code of codes) {
+    if (REGIONS_START_ORDER.has(code)) keyRegions.add(code);
+    else otherRegions.push(code);
+  }
+
+  const sortedKeyRegions = Array.from(REGIONS_START_ORDER).filter((code) =>
+    keyRegions.has(code)
+  );
+
+  return {
+    allRegionCodes: [...sortedKeyRegions, ...otherRegions],
+    lastKeyRegionIndex: keyRegions.size > 0 ? keyRegions.size - 1 : null,
+  };
+}
+
 export function getRegionNames(brand?: Brand) {
   return regions(brand).map((region) => region.name);
 }
@@ -59,11 +106,15 @@ export function getRegionByCode(regionCode: string, brand?: Brand) {
   if (!regionCode) {
     return null;
   }
-  return regions(brand).find((region) => (region.code.toLowerCase() === regionCode.toLowerCase()));
+  return regions(brand).find(
+    (region) => region.code.toLowerCase() === regionCode.toLowerCase()
+  );
 }
 
 export function getRegionByCurrency(currencyCode: string, brand?: Brand) {
-  return regions(brand).find((region) => (region.currencyCode.toLowerCase() === currencyCode.toLowerCase()));
+  return regions(brand).find(
+    (region) => region.currencyCode.toLowerCase() === currencyCode.toLowerCase()
+  );
 }
 
 export function getDefaultRegion(brand?: Brand) {
@@ -72,7 +123,7 @@ export function getDefaultRegion(brand?: Brand) {
 
 export function getRegionNameByCode(code: string, brand?: Brand) {
   const region = getRegionByCode(code, brand);
-  return region && region.name || null;
+  return (region && region.name) || null;
 }
 
 export function getDefaultRegionCode(brand?: Brand) {
@@ -87,7 +138,10 @@ export function getCurrencyCodes(brand?: string) {
   return Object.keys(currencies(brand));
 }
 
-export function getPaymentMethodsByCurrencyCode(currencyCode: string, brand?: string) {
+export function getPaymentMethodsByCurrencyCode(
+  currencyCode: string,
+  brand?: string
+) {
   if (!currencies(brand)[currencyCode]) {
     return [];
   }
@@ -105,7 +159,7 @@ export function getRegionLang(brand?: Brand) {
 
 export function getRegionReferralAmountByCode(code: string, brand?: Brand) {
   const region = getRegionByCode(code, brand);
-  return region && region.referralAmount || null;
+  return (region && region.referralAmount) || null;
 }
 
 export function getRegionPhonePrefix(brand?: Brand) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,8 @@ const zeroDecimalCurrencies = [
   "XPF",
 ];
 
-const REGIONS_START_ORDER = new Set(["AU", "US", "GB", "NZ", "SG"]);
+// Custom order of countries that are more important to LE, showing it before other countries on CP and admin
+const REGIONS_START_ORDER = ["AU", "US", "GB", "NZ", "SG"];
 
 export function getPriorityPhoneNumbers(brand?: string) {
   return priorityPhoneNumbers[brand || LUXURY_ESCAPES];
@@ -40,7 +41,7 @@ export function getPriorityPhoneNumbers(brand?: string) {
 
 export function getPriorityPhoneNumberByCode(
   regionCode: string,
-  brand?: string,
+  brand?: string
 ) {
   if (!regionCode) {
     return null;
@@ -50,7 +51,7 @@ export function getPriorityPhoneNumberByCode(
   if (priorityNumbers.length > 0) {
     const pNumber = priorityNumbers.find(
       (phoneNumber) =>
-        phoneNumber.code.toLowerCase() === regionCode.toLowerCase(),
+        phoneNumber.code.toLowerCase() === regionCode.toLowerCase()
     );
 
     return pNumber ? pNumber : null;
@@ -71,33 +72,24 @@ export function getRegionCodes(brand?: Brand) {
   return regions(brand).map((region) => region.code);
 }
 
-// TODO: Implement avoid codes
 export function getRegionCodesSortedByKeyRegions(
   brand?: Brand,
-  excludedRegions?: string[],
+  excludedRegions?: string[]
 ) {
   const codes = excludedRegions
     ? getRegionCodes(brand).filter((code) => !excludedRegions.includes(code))
     : getRegionCodes(brand);
 
-  const keyRegions = new Set<string>([]);
-  const otherRegions: string[] = [];
-
-  for (const code of codes) {
-    if (REGIONS_START_ORDER.has(code)) {
-      keyRegions.add(code);
-    } else {
-      otherRegions.push(code);
-    }
-  }
-
-  const sortedKeyRegions = Array.from(REGIONS_START_ORDER).filter((code) =>
-    keyRegions.has(code),
+  const keyRegions = Array.from(REGIONS_START_ORDER).filter((code) =>
+    codes.includes(code)
+  );
+  const otherRegions = codes.filter(
+    (code) => !REGIONS_START_ORDER.includes(code)
   );
 
   return {
-    allRegionCodes: [...sortedKeyRegions, ...otherRegions],
-    lastKeyRegionIndex: keyRegions.size > 0 ? keyRegions.size - 1 : null,
+    allRegionCodes: [...keyRegions, ...otherRegions],
+    lastKeyRegionIndex: keyRegions.length > 0 ? keyRegions.length - 1 : null,
   };
 }
 
@@ -110,13 +102,13 @@ export function getRegionByCode(regionCode: string, brand?: Brand) {
     return null;
   }
   return regions(brand).find(
-    (region) => region.code.toLowerCase() === regionCode.toLowerCase(),
+    (region) => region.code.toLowerCase() === regionCode.toLowerCase()
   );
 }
 
 export function getRegionByCurrency(currencyCode: string, brand?: Brand) {
   return regions(brand).find(
-    (region) => region.currencyCode.toLowerCase() === currencyCode.toLowerCase(),
+    (region) => region.currencyCode.toLowerCase() === currencyCode.toLowerCase()
   );
 }
 
@@ -143,7 +135,7 @@ export function getCurrencyCodes(brand?: string) {
 
 export function getPaymentMethodsByCurrencyCode(
   currencyCode: string,
-  brand?: string,
+  brand?: string
 ) {
   if (!currencies(brand)[currencyCode]) {
     return [];


### PR DESCRIPTION
## Story tracking
Jira: https://aussiecommerce.atlassian.net/browse/CRO-27888

Figma: N/A

## Summary of the changes
Implement region listing to begin with business key regions.

The new method `getRegionCodesSortedByKeyRegions` returns sorted region codes by business key regions.
eg: ["AU", "US", "GB", "NZ", "SG", ...]

It's the same rule already presented on CP:
![Screenshot 2023-11-06 at 21 45 45](https://github.com/lux-group/lib-regions/assets/54781023/b3056a9e-8321-4500-97c0-14904e0c17fc)
