### PR TITLE
fix: Correct constant usage in regions.ts

### DIFF
--- a/src/regions.ts
+++ b/src/regions.ts
@@ -64,7 +64,7 @@ export interface Region {
 export const LUXURY_ESCAPES = "luxuryescapes";
 
 export const BRANDS = [
-  LUXURY_ESCAPES,
+  "LUXURY_ESCAPES",
   "scooponexperience",
   "scoopontravel",
   "kogantravel",


### PR DESCRIPTION
Fixed the incorrect constant usage in regions.ts from LUXURY_ESCAPES to "LUXURY_ESCAPES" for consistency and clarity.