### PR TITLE
Add stripe v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.7",
+  "version": "5.6.8",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -182,6 +182,7 @@ export const currencies: BrandCurrencies = {
         "applepay",
         "googlepay",
         "stripe_3ds",
+        "stripe_3ds_v2",
       ],
     },
     HKD: {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -299,6 +299,19 @@ describe("getPaymentMethodsByCurrencyCode()", function () {
       "stripe_3ds",
     ]);
   });
+
+  it("should return an array of payment methods for brand to luxuryescapes for EUR", function () {
+    expect(regionModule.getPaymentMethodsByCurrencyCode("EUR")).to.deep.equal([
+      "le_credit",
+        "stripe",
+        "deposit_stripe",
+        "giftcard",
+        "applepay",
+        "googlepay",
+        "stripe_3ds",
+        "stripe_3ds_v2"
+    ]);
+  });
 });
 
 describe("getZeroDecimalCurrencies()", function () {


### PR DESCRIPTION
We want to migrate FE code to point to stripe v2 in the BE. This has to be done in a phased manner so that changes are not deployed for all the regions overnight especially because some of the regions still has instalments feature ongoing (pending instalments). Currently we will go with EUR