### PR TITLE
[CRO-4035] Remove club vistara

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.18",
+  "version": "5.6.19",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -210,7 +210,6 @@ export const currencies: BrandCurrencies = {
         "deposit_stripe",
         "razorpay",
         "giftcard",
-        "vistara",
         "stripe_3ds",
         "stripe_payment_element_card",
       ],

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -297,7 +297,6 @@ describe("getPaymentMethodsByCurrencyCode()", function () {
       "deposit_stripe",
       "razorpay",
       "giftcard",
-      "vistara",
       "stripe_3ds",
       "stripe_payment_element_card",
     ]);


### PR DESCRIPTION
We are ending the partnership with Club Vistara and the company itself no longer exists as it was aquired by Air India. This means we want to remove references to it across the stack.

This PR removes the references in lib-regions