### PR TITLE
publish beta version step on PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,10 @@ defaults: &defaults
   docker:
     - image: cimg/node:14.18.2
 
+feature-branches: &feature-branches
+  branches:
+    ignore: master
+
 jobs:
   build:
     <<: *defaults
@@ -44,6 +48,25 @@ jobs:
           name: Publish package
           command: npm publish
 
+  publish-beta:
+    <<: *defaults
+    type: approval
+    steps:
+      - attach_workspace:
+          at: ~/repo
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
+      - run:
+          name: View pre-publish packages
+          command: npm view @luxuryescapes/lib-regions versions --json
+      - run:
+          name: Publish package
+          command: npm publish --tag beta
+      - run:
+          name: View post-pubish packages
+          command: sleep 5 && npm view @luxuryescapes/lib-regions versions --json
+
 workflows:
   version: 2
   build-publish:
@@ -57,6 +80,18 @@ workflows:
           filters:
             branches:
               only: master
+
+      - hold-publish-beta:
+          type: approval
+          requires:
+            - build
+          filters: *feature-branches
+
+      - publish-beta:
+          context: LE
+          requires:
+            - hold-publish-beta
+          filters: *feature-branches
 
 experimental:
   notify:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.21-beta.1",
+  "version": "5.6.21",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.20",
+  "version": "5.6.21-beta.1",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -18,7 +18,8 @@
     "prepare": "yarn run build",
     "prepublishOnly": "yarn test && yarn run lint",
     "preversion": "yarn run lint",
-    "postversion": "git push && git push --tags"
+    "postversion": "git push && git push --tags",
+    "prepare:beta": "npm version prerelease --preid=beta"
   },
   "devDependencies": {
     "@types/chai": "^4.3.5",


### PR DESCRIPTION
Currently we need to fully publish the lib-region package so we can test it out end to end with CP on Staging or Canary. 
the publish require PR approval and sometime takes a while to get approved. 

I'm adding pre-publish/beta release `manual` step on pull request so dev can test lib region change end to end on staging/canary and speedup development process. 


## Demo of Beta usage on CP:
https://github.com/lux-group/www-le-customer/pull/21526

## Output
**Circle CI**
<img width="1224" alt="Screenshot 2024-08-16 at 3 37 46 PM" src="https://github.com/user-attachments/assets/c993111e-bf31-461e-b252-daad9539bf73">


**NPM View Output**
```
➜  ~ npm view @luxuryescapes/lib-regions         

@luxuryescapes/lib-regions@5.6.20 | UNLICENSED | deps: none | versions: 160
Region information for Luxury Escapes
https://github.com/brandsExclusive/lib-regions#readme

dist
.tarball: https://registry.npmjs.org/@luxuryescapes/lib-regions/-/lib-regions-5.6.20.tgz
.shasum: 4ed6f78da88bdcf174f0ef3eda5921b57e1a1c99
.integrity: sha512-32tAic4A74LVcPpOTjXhzFTx+SRCDykAY+QXlKROktkKF6unDQbza/TdrF7F96RGdIj68mrOksy/unF6noAlvw==
.unpackedSize: 298.4 kB

maintainers:
- venkatle <venkat.balachandran@luxuryescapes.com>
....

dist-tags:
beta: 5.6.21-beta.1  latest: 5.6.20       

```