### PR TITLE
PP-2089 EU stripe element v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.22-beta.0",
+  "version": "5.6.22",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.21",
+  "version": "5.6.22-beta.0",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -193,6 +193,7 @@ export const currencies: BrandCurrencies = {
         "googlepay",
         "stripe_3ds",
         "stripe_3ds_v2",
+        "stripe_payment_element_card",
       ],
     },
     HKD: {
@@ -426,6 +427,7 @@ export const currencies: BrandCurrencies = {
         "applepay",
         "googlepay",
         "stripe_3ds",
+        "stripe_payment_element_card",
       ],
     },
     USD: {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -311,7 +311,8 @@ describe("getPaymentMethodsByCurrencyCode()", function () {
         "applepay",
         "googlepay",
         "stripe_3ds",
-        "stripe_3ds_v2"
+        "stripe_3ds_v2",
+        "stripe_payment_element_card"
     ]);
   });
 });


### PR DESCRIPTION
Ticket: https://aussiecommerce.atlassian.net/browse/PP-2089

Enable stripe element for EU regions. It's a base work for to enable iDEAL payment method for Netherlands (NL).

Note: `Beta` version is tested on Customer Portal
https://github.com/lux-group/www-le-customer/pull/21553


## Demo

### Netherlands (NL)
https://www.loom.com/share/6e81302ac6754faea5537d0e9acbbc88

### United Kingdom (GB)
https://www.loom.com/share/0290a84d64224b3599093dd59a7d7169

### Germany (DE)
https://www.loom.com/share/ffba218564224f7faf4de950593c679e

### France (DE)
https://www.loom.com/share/de8cc30cd80a440d8f48c9a1d75d5223

### Italy (IT)
https://www.loom.com/share/b51b8a3090a04bfbb4896b45b14f0d24

### Spain (ES)
https://www.loom.com/share/c8c9ba41ec264499898891d93ad08782

### Irland (IE)
https://www.loom.com/share/864e65906d3d4b07a83e718a93557cf9
