### PR TITLE
Feature/pp 2081 enable payment element

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.24",
+  "version": "5.6.25",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.26-beta.0",
+  "version": "5.6.26-beta.1",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.26-beta.2",
+  "version": "5.6.26",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.25",
+  "version": "5.6.26-beta.0",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.26-beta.1",
+  "version": "5.6.26-beta.2",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -109,6 +109,7 @@ export const currencies: BrandCurrencies = {
       paymentMethods: [
         "stripe",
         "stripe_3ds",
+        "stripe_payment_element_card",
       ],
     },
   },
@@ -169,6 +170,7 @@ export const currencies: BrandCurrencies = {
         "applepay",
         "googlepay",
         "stripe_3ds",
+        "stripe_payment_element_card",
       ],
     },
     CNY: {
@@ -340,6 +342,7 @@ export const currencies: BrandCurrencies = {
         // "applepay", // Apple Pay is not supported in RU
         // "googlepay", // Google Pay is not supported in RU
         "stripe_3ds",
+        "stripe_payment_element_card",
       ],
     },
     SAR: {
@@ -403,6 +406,7 @@ export const currencies: BrandCurrencies = {
         "stripe_3ds",
         // "applepay", Apple Pay is not supported in South Africa
         // "googlepay", Google Pay is not supported in South Africa
+        "stripe_payment_element_card",
       ],
     },
     AED: {

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -118,12 +118,14 @@ export const currencies: BrandCurrencies = {
       paymentMethods: [
         "stripe",
         "stripe_3ds",
+        "stripe_payment_element_card",
       ],
     },
     NZD: {
       paymentMethods: [
         "stripe",
         "stripe_3ds",
+        "stripe_payment_element_card",
       ],
     },
   },


### PR DESCRIPTION
## Story tracking
Feature/pp 2081 enable payment element

## Summary of the changes
- Enable Payment element for Lebt
- Enable Payment element for CAD for LE brand

# Loom lebt
https://www.loom.com/share/c4069dca80df463f9c70abb3afd812f1

# LE CAD
![Screenshot 2024-09-02 at 10 56 58 am](https://github.com/user-attachments/assets/fa342459-3719-4de5-bb3b-e363fde5daf6)

