### PR TITLE
add flying blue support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.28",
+  "version": "5.6.29",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -338,16 +338,14 @@ describe("getPaymentMethodsByCurrencyCode()", function () {
 describe("getPaymentMethodsByRegion()", function () {
   it("NL region to luxuryescapes", function () {
     expect(regionModule.getPaymentMethodsByRegion("NL", "luxuryescapes")).to.deep.equal([
-      "le_credit",
-      "stripe",
-      "deposit_stripe",
-      "giftcard",
-      "applepay",
-      "googlepay",
-      "stripe_3ds",
-      "stripe_3ds_v2",
-      "stripe_payment_element_card",
       "stripe_payment_element_ideal",
+      "flying_blue",
+    ]);
+  });
+
+  it("FR region to luxuryescapes", function () {
+    expect(regionModule.getPaymentMethodsByRegion("FR", "luxuryescapes")).to.deep.equal([
+     "flying_blue",
     ]);
   });
 });

--- a/src/paymentMethodsByregion.ts
+++ b/src/paymentMethodsByregion.ts
@@ -24,16 +24,13 @@ export const paymentMethodsByRegion: PaymentMethodsByRegion = {
     },
     NL: {
       paymentMethods: [
-        "le_credit",
-        "stripe",
-        "deposit_stripe",
-        "giftcard",
-        "applepay",
-        "googlepay",
-        "stripe_3ds",
-        "stripe_3ds_v2",
-        "stripe_payment_element_card",
         "stripe_payment_element_ideal",
+        "flying_blue",
+      ],
+    },
+    FR: {
+      paymentMethods: [
+        "flying_blue",
       ],
     },
   },


### PR DESCRIPTION
1. Add support for new payment type - flying blue. This type is enabled only for France and Netherlands 
2. Remove other supported payment types from choosing based on region as the currency 'EUR' supports others for NL.