### PR TITLE
[OPERX-151] Add cancellation retention phone numbers for several regions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.35-beta.0",
+  "version": "5.6.35-beta.1",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.37-beta.0",
+  "version": "5.6.36",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.34",
+  "version": "5.6.35-beta.0",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.35",
+  "version": "5.6.36",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.36",
+  "version": "5.6.37-beta.0",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -467,3 +467,14 @@ describe("Insurance countries", function () {
     expect(isoCode).to.equal("AU")
   });
 });
+
+describe('getDefaultCancellationRetentionPhoneNumber', () => {
+  it('should return the AU cancellation retention phone number', () => {
+    const phoneNumber = regionModule.getDefaultCancellationRetentionPhoneNumber()
+
+    expect(phoneNumber).to.deep.equal({
+      number: "1300739349",
+      humanReadable: "1300 739 349",
+    })
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,10 +241,10 @@ export function getInsuranceCountryTwoLetterCodeByName(name: string) {
 }
 
 export function getDefaultCancellationRetentionPhoneNumber(brand?: Brand) {
-  const auRegion = regions(brand).find((region) => region.code === 'AU')
-  const retentionContact = auRegion?.contacts.find((contact) => contact.type === 'cancellationRetention')
+  const auRegion = regions(brand).find((region) => region.code === "AU");
+  const retentionContact = auRegion?.contacts.find((contact) => contact.type === "cancellationRetention");
   return {
-    number: retentionContact?.local.number ?? '1300739349',
-    humanReadable: retentionContact?.local.humanReadable ?? '1300 739 349'
-  }
+    number: retentionContact?.local.number ?? "1300739349",
+    humanReadable: retentionContact?.local.humanReadable ?? "1300 739 349",
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,3 +239,12 @@ export function getInsuranceCountryTwoLetterCodeByName(name: string) {
   const insuranceCountry = insuranceCountries.find((country) => country.name === name);
   return insuranceCountry?.two_letter_country_code;
 }
+
+export function getDefaultCancellationRetentionPhoneNumber(brand?: Brand) {
+  const auRegion = regions(brand).find((region) => region.code === 'AU')
+  const retentionContact = auRegion?.contacts.find((contact) => contact.type === 'cancellationRetention')
+  return {
+    number: retentionContact?.local.number ?? '1300739349',
+    humanReadable: retentionContact?.local.humanReadable ?? '1300 739 349'
+  }
+}

--- a/src/regions.ts
+++ b/src/regions.ts
@@ -13,7 +13,7 @@ interface OfferUrgencyTag {
   };
 }
 
-type ContactType = "general" | "highValue" | "cruises" | "tours" | "ultralux" | "supportAssistant" | "supportAssistantSalesFlow" | "luxPlus" | "midValue";
+type ContactType = "general" | "highValue" | "cruises" | "tours" | "ultralux" | "supportAssistant" | "supportAssistantSalesFlow" | "luxPlus" | "midValue" | "cancellationRetention"
 
 interface PhoneNumber {
   humanReadable: string;
@@ -224,6 +224,18 @@ export const regions: BrandRegions = {
           },
           default: "local",
         },
+        {
+          type: "cancellationRetention",
+          local: {
+            humanReadable: "1300 739 349",
+            number: "1300739349",
+          },
+          international: {
+            humanReadable: "+61 3 7032 3381",
+            number: "+61370323381",
+          },
+          default: "local"
+        }
       ],
       mailingAddress: DEFAULT_MAILING_ADDRESS,
       latitudeThreshold: 999,
@@ -1157,6 +1169,18 @@ export const regions: BrandRegions = {
           },
           default: "local",
         },
+        {
+          type: "cancellationRetention",
+          local: {
+            humanReadable: "0800 130 064",
+            number: "0800130064",
+          },
+          international: {
+            humanReadable: "+61 3 7032 3381",
+            number: "+61370323381",
+          },
+          default: "local"
+        }
       ],
       mailingAddress: DEFAULT_MAILING_ADDRESS,
       referralAmount: 50,
@@ -1785,6 +1809,18 @@ export const regions: BrandRegions = {
           },
           default: "local",
         },
+        {
+          type: "cancellationRetention",
+          local: {
+            humanReadable: "0800 680 0085",
+            number: "08006800085",
+          },
+          international: {
+            humanReadable: "+61 3 7032 3381",
+            number: "+61370323381",
+          },
+          default: "local"
+        }
       ],
       mailingAddress: DEFAULT_MAILING_ADDRESS,
       referralAmount: 25,
@@ -1853,6 +1889,18 @@ export const regions: BrandRegions = {
           },
           default: "local",
         },
+        {
+          type: "cancellationRetention",
+          local: {
+            humanReadable: "888 300 2414",
+            number: "8883002414",
+          },
+          international: {
+            humanReadable: "+61 3 7032 3381",
+            number: "+61370323381",
+          },
+          default: "local"
+        }
       ],
       mailingAddress: DEFAULT_MAILING_ADDRESS,
       referralAmount: 50,

--- a/src/regions.ts
+++ b/src/regions.ts
@@ -13,7 +13,7 @@ interface OfferUrgencyTag {
   };
 }
 
-type ContactType = "general" | "highValue" | "cruises" | "tours" | "ultralux" | "supportAssistant" | "supportAssistantSalesFlow" | "luxPlus" | "midValue" | "cancellationRetention"
+type ContactType = "general" | "highValue" | "cruises" | "tours" | "ultralux" | "supportAssistant" | "supportAssistantSalesFlow" | "luxPlus" | "midValue" | "cancellationRetention";
 
 interface PhoneNumber {
   humanReadable: string;
@@ -234,8 +234,8 @@ export const regions: BrandRegions = {
             humanReadable: "+61 3 7032 3381",
             number: "+61370323381",
           },
-          default: "local"
-        }
+          default: "local",
+        },
       ],
       mailingAddress: DEFAULT_MAILING_ADDRESS,
       latitudeThreshold: 999,
@@ -1179,8 +1179,8 @@ export const regions: BrandRegions = {
             humanReadable: "+61 3 7032 3381",
             number: "+61370323381",
           },
-          default: "local"
-        }
+          default: "local",
+        },
       ],
       mailingAddress: DEFAULT_MAILING_ADDRESS,
       referralAmount: 50,
@@ -1819,8 +1819,8 @@ export const regions: BrandRegions = {
             humanReadable: "+61 3 7032 3381",
             number: "+61370323381",
           },
-          default: "local"
-        }
+          default: "local",
+        },
       ],
       mailingAddress: DEFAULT_MAILING_ADDRESS,
       referralAmount: 25,
@@ -1899,8 +1899,8 @@ export const regions: BrandRegions = {
             humanReadable: "+61 3 7032 3381",
             number: "+61370323381",
           },
-          default: "local"
-        }
+          default: "local",
+        },
       ],
       mailingAddress: DEFAULT_MAILING_ADDRESS,
       referralAmount: 50,


### PR DESCRIPTION
## Story tracking
https://aussiecommerce.atlassian.net/browse/OPERX-151
CP PR: https://github.com/lux-group/www-le-customer/pull/22641

## Summary of changes
The cancellation retention modal needs to be updated such that it can display the correct phone number depending on the region of the order the customer is trying to cancel.

To achieve this, `lib-regions` needs to be updated to hold information about the cancellation retention phone numbers for regions where this is supported. This PR adds the cancellation retention phone number for the following regions:
- AU (this is hardcoded into CP currently but will be refactored to use the value declared in this lib)
- NZ
- US
- GB

The values defined here will be consumed by CP and will be shown in the cancellation retention modal.