### PR TITLE
[CRO-4583]: Include Hong Kong and Taiwan into admin priority list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.38-beta.1",
+  "version": "5.6.38",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.37",
+  "version": "5.6.38-beta.0",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.38-beta.0",
+  "version": "5.6.38-beta.1",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -28,7 +28,7 @@ describe("getRegionCodesSortedByKeyRegions", () => {
 
   it("should return other region codes sorted and after key region codes", () => {
     const otherRegionCodes = allRegionCodes.slice(5, 10);
-    expect(otherRegionCodes).to.deep.equal(["CA", "CN", "FR", "DE", "HK"]);
+    expect(otherRegionCodes).to.deep.equal(["CA", "CN", "FR", "DE", "IN"]);
   });
 
   it("should not return excluded regions", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -23,11 +23,11 @@ describe("getRegionCodesSortedByKeyRegions", () => {
   });
 
   it("should return the index of last key region", () => {
-    expect(lastKeyRegionIndex).to.be.equal(4);
+    expect(lastKeyRegionIndex).to.be.equal(6);
   });
 
   it("should return other region codes sorted and after key region codes", () => {
-    const otherRegionCodes = allRegionCodes.slice(5, 10);
+    const otherRegionCodes = allRegionCodes.slice(7, 12);
     expect(otherRegionCodes).to.deep.equal(["CA", "CN", "FR", "DE", "IN"]);
   });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -18,8 +18,8 @@ describe("getRegionCodesSortedByKeyRegions", () => {
     regionModule.getRegionCodesSortedByKeyRegions();
 
   it("should return key region codes sorted and as initial elements", () => {
-    const keyRegionCodes = allRegionCodes.slice(0, 5);
-    expect(keyRegionCodes).to.deep.equal(["AU", "US", "GB", "NZ", "SG"]);
+    const keyRegionCodes = allRegionCodes.slice(0, 7);
+    expect(keyRegionCodes).to.deep.equal(["AU", "US", "GB", "NZ", "SG", "HK", "TW"]);
   });
 
   it("should return the index of last key region", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ const zeroDecimalCurrencies = [
 ];
 
 // Custom order of countries that are more important to LE, showing it before other countries on CP and admin
-const REGIONS_START_ORDER = ["AU", "US", "GB", "NZ", "SG"];
+const REGIONS_START_ORDER = ["AU", "US", "GB", "NZ", "SG", "HK", "TW"];
 
 export function getPriorityPhoneNumbers(brand?: string) {
   return priorityPhoneNumbers[brand || LUXURY_ESCAPES];


### PR DESCRIPTION
JIRA: https://aussiecommerce.atlassian.net/browse/CRO-4583

We want to move up Hong Kong and Taiwan regions on the curation list selection:
![image](https://github.com/user-attachments/assets/87bb42dd-408b-433a-825e-ca3bc0afddd1)

This method is only used by admin: https://github.com/search?q=org%3Alux-group%20getRegionCodesSortedByKeyRegions&type=code

## Testing
Unit tests was updated