### PR TITLE
add azupay to Aus region

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.46",
+  "version": "5.6.47",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -189,6 +189,7 @@ export const currencies: BrandCurrencies = {
         "stripe_payment_element_card",
         "stripe_payment_element_klarna",
         "secure_payment",
+        "azupay_pay_id",
       ],
     },
     CAD: {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -280,6 +280,7 @@ describe("getPaymentMethodsByCurrencyCode()", function () {
       "stripe_payment_element_card",
       "stripe_payment_element_klarna",
       "secure_payment",
+      "azupay_pay_id",
     ]);
   });
 


### PR DESCRIPTION
Azupay is a new payment provider and we intend to use the PayId payment method of their's in Au region.
This PR adds the payment method to Au region for luxury escapes brand.