### PR TITLE
CRO-4754: Include CFMR enabled origin countries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.48",
+  "version": "5.6.49",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { currencies as _currencies } from "./currencies";
 import { ExtendedRegion as Region, extendedRegions } from "./extended";
-import { ALLOWED_ORIGIN_COUNTRIES, COVER_GENIUS_COUNTRIES, UNIVERSAL_COUNTRIES } from "./insurance";
+import { ALLOWED_CFMR_ORIGIN_COUNTRIES, ALLOWED_ORIGIN_COUNTRIES, COVER_GENIUS_COUNTRIES, UNIVERSAL_COUNTRIES } from "./insurance";
 import { PaymentMethodLimit, paymentMethodLimitsByRegion as _paymentMethodLimitsByRegion } from "./paymentMethodLimitsByRegion";
 import { paymentMethodsByRegion as _paymentMethodsByRegion } from "./paymentMethodsByRegion";
 import { priorityPhoneNumbers } from "./priorityPhoneNumbers";
@@ -230,6 +230,10 @@ export function getInsuranceCountries() {
 
 export function getInsuranceAllowedOriginCountries() {
   return ALLOWED_ORIGIN_COUNTRIES;
+}
+
+export function getInsuranceCFMRAllowedOriginCountries() {
+  return ALLOWED_CFMR_ORIGIN_COUNTRIES;
 }
 
 export function getInsuranceCountryNames() {

--- a/src/insurance.ts
+++ b/src/insurance.ts
@@ -1,4 +1,5 @@
 export const ALLOWED_ORIGIN_COUNTRIES = ["NZ", "AU", "SG", "MY", "TH", "IN", "HK"];
+export const ALLOWED_CFMR_ORIGIN_COUNTRIES = ['AU', 'NZ', 'US', 'GB', 'CA', 'VN', 'AE', 'SA', 'QA', 'FR', 'DE', 'IE', 'IT', 'ES', 'NL'];
 
 export const COVER_GENIUS_COUNTRIES = [
   {

--- a/src/insurance.ts
+++ b/src/insurance.ts
@@ -1,5 +1,5 @@
 export const ALLOWED_ORIGIN_COUNTRIES = ["NZ", "AU", "SG", "MY", "TH", "IN", "HK"];
-export const ALLOWED_CFMR_ORIGIN_COUNTRIES = ['AU', 'NZ', 'US', 'GB', 'CA', 'VN', 'AE', 'SA', 'QA', 'FR', 'DE', 'IE', 'IT', 'ES', 'NL'];
+export const ALLOWED_CFMR_ORIGIN_COUNTRIES = ["AU", "NZ", "US", "GB", "CA", "VN", "AE", "SA", "QA", "FR", "DE", "IE", "IT", "ES", "NL"];
 
 export const COVER_GENIUS_COUNTRIES = [
   {


### PR DESCRIPTION
The countries where CFMR (Cancel for Many Reasons) is enabled differ from those for insurance.
This PR adds the CFMR-enabled countries so they can be used across different projects (currently CP and svc-insurance).