### PR TITLE
[OPEX-3004] Improved phone number validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.50",
+  "version": "5.6.51-beta.0",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.51-beta.4",
+  "version": "5.6.51-beta.5",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.51-beta.7",
+  "version": "5.6.51",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.51-beta.0",
+  "version": "5.6.51-beta.1",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "ts-node": "^10.9.1",
     "tslint": "^5.20.1",
     "typescript": "^5.0.4"
+  },
+  "dependencies": {
+    "libphonenumber-js": "^1.11.20"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.51",
+  "version": "5.6.52-beta.0",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.51-beta.1",
+  "version": "5.6.51-beta.2",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.51-beta.5",
+  "version": "5.6.51-beta.6",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.51-beta.3",
+  "version": "5.6.51-beta.4",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.52-beta.0",
+  "version": "5.6.52-beta.1",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
-    "libphonenumber-js": "^1.11.20"
+    "phone": "^3.1.58"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.51-beta.2",
+  "version": "5.6.51-beta.3",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.51-beta.6",
+  "version": "5.6.51-beta.7",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.52-beta.1",
+  "version": "5.6.51",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 import { currencies as _currencies } from "./currencies";
 import { ExtendedRegion as Region, extendedRegions } from "./extended";
 import { ALLOWED_CFMR_ORIGIN_COUNTRIES, ALLOWED_ORIGIN_COUNTRIES, COVER_GENIUS_COUNTRIES, UNIVERSAL_COUNTRIES } from "./insurance";
+import { CountryCode, isPossiblePhoneNumber } from "libphonenumber-js";
 import { PaymentMethodLimit, paymentMethodLimitsByRegion as _paymentMethodLimitsByRegion } from "./paymentMethodLimitsByRegion";
 import { paymentMethodsByRegion as _paymentMethodsByRegion } from "./paymentMethodsByRegion";
 import { priorityPhoneNumbers } from "./priorityPhoneNumbers";
 import { Brand, LUXURY_ESCAPES } from "./regions";
-import { isPossiblePhoneNumber } from "libphonenumber-js";
 
 export { Region };
 
@@ -142,7 +142,7 @@ export function isRegionPhoneNumberValid(
 
 export function altIsRegionPhoneNumberValid(
   { phoneNumber, regionCode }: { phoneNumber: string, regionCode: string }) {
-    return isPossiblePhoneNumber(phoneNumber, regionCode);
+    return isPossiblePhoneNumber(phoneNumber, regionCode as CountryCode);
 }
 
 export function getDefaultRegion(brand?: Brand) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
+import { CountryCode, isPossiblePhoneNumber } from "libphonenumber-js";
 import { currencies as _currencies } from "./currencies";
 import { ExtendedRegion as Region, extendedRegions } from "./extended";
 import { ALLOWED_CFMR_ORIGIN_COUNTRIES, ALLOWED_ORIGIN_COUNTRIES, COVER_GENIUS_COUNTRIES, UNIVERSAL_COUNTRIES } from "./insurance";
-import { CountryCode, isPossiblePhoneNumber } from "libphonenumber-js";
 import { PaymentMethodLimit, paymentMethodLimitsByRegion as _paymentMethodLimitsByRegion } from "./paymentMethodLimitsByRegion";
 import { paymentMethodsByRegion as _paymentMethodsByRegion } from "./paymentMethodsByRegion";
 import { priorityPhoneNumbers } from "./priorityPhoneNumbers";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 // import { CountryCode, isPossiblePhoneNumber } from "libphonenumber-js/min";
-import { phone } from "phone";
 import { currencies as _currencies } from "./currencies";
 import { ExtendedRegion as Region, extendedRegions } from "./extended";
 import { ALLOWED_CFMR_ORIGIN_COUNTRIES, ALLOWED_ORIGIN_COUNTRIES, COVER_GENIUS_COUNTRIES, UNIVERSAL_COUNTRIES } from "./insurance";
@@ -141,9 +140,9 @@ export function isRegionPhoneNumberValid(
   return region.phoneRegex.test(phoneNumber);
 }
 
-export function altIsRegionPhoneNumberValid(
+export async function altIsRegionPhoneNumberValid(
   { phoneNumber, regionCode }: { phoneNumber: string, regionCode: string }) {
-    // return isPossiblePhoneNumber(phoneNumber, regionCode as CountryCode);
+    const { phone } = await import('phone')
     return phone(phoneNumber, { country: regionCode }).isValid;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { CountryCode, isPossiblePhoneNumber } from "libphonenumber-js";
+import { CountryCode, isPossiblePhoneNumber } from "libphonenumber-js/min";
 import { currencies as _currencies } from "./currencies";
 import { ExtendedRegion as Region, extendedRegions } from "./extended";
 import { ALLOWED_CFMR_ORIGIN_COUNTRIES, ALLOWED_ORIGIN_COUNTRIES, COVER_GENIUS_COUNTRIES, UNIVERSAL_COUNTRIES } from "./insurance";

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { PaymentMethodLimit, paymentMethodLimitsByRegion as _paymentMethodLimits
 import { paymentMethodsByRegion as _paymentMethodsByRegion } from "./paymentMethodsByRegion";
 import { priorityPhoneNumbers } from "./priorityPhoneNumbers";
 import { Brand, LUXURY_ESCAPES } from "./regions";
+import { isPossiblePhoneNumber } from "libphonenumber-js";
 
 export { Region };
 
@@ -137,6 +138,11 @@ export function isRegionPhoneNumberValid(
   }
 
   return region.phoneRegex.test(phoneNumber);
+}
+
+export function altIsRegionPhoneNumberValid(
+  { phoneNumber, regionCode }: { phoneNumber: string, regionCode: string }) {
+    return isPossiblePhoneNumber(phoneNumber, regionCode);
 }
 
 export function getDefaultRegion(brand?: Brand) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // import { CountryCode, isPossiblePhoneNumber } from "libphonenumber-js/min";
-import { phone } from 'phone';
+import { phone } from "phone";
 import { currencies as _currencies } from "./currencies";
 import { ExtendedRegion as Region, extendedRegions } from "./extended";
 import { ALLOWED_CFMR_ORIGIN_COUNTRIES, ALLOWED_ORIGIN_COUNTRIES, COVER_GENIUS_COUNTRIES, UNIVERSAL_COUNTRIES } from "./insurance";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import { CountryCode, isPossiblePhoneNumber } from "libphonenumber-js/min";
+// import { CountryCode, isPossiblePhoneNumber } from "libphonenumber-js/min";
+import { phone } from 'phone';
 import { currencies as _currencies } from "./currencies";
 import { ExtendedRegion as Region, extendedRegions } from "./extended";
 import { ALLOWED_CFMR_ORIGIN_COUNTRIES, ALLOWED_ORIGIN_COUNTRIES, COVER_GENIUS_COUNTRIES, UNIVERSAL_COUNTRIES } from "./insurance";
@@ -142,7 +143,8 @@ export function isRegionPhoneNumberValid(
 
 export function altIsRegionPhoneNumberValid(
   { phoneNumber, regionCode }: { phoneNumber: string, regionCode: string }) {
-    return isPossiblePhoneNumber(phoneNumber, regionCode as CountryCode);
+    // return isPossiblePhoneNumber(phoneNumber, regionCode as CountryCode);
+    return phone(phoneNumber, { country: regionCode }).isValid;
 }
 
 export function getDefaultRegion(brand?: Brand) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-// import { CountryCode, isPossiblePhoneNumber } from "libphonenumber-js/min";
 import { currencies as _currencies } from "./currencies";
 import { ExtendedRegion as Region, extendedRegions } from "./extended";
 import { ALLOWED_CFMR_ORIGIN_COUNTRIES, ALLOWED_ORIGIN_COUNTRIES, COVER_GENIUS_COUNTRIES, UNIVERSAL_COUNTRIES } from "./insurance";

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,7 @@ export function isRegionPhoneNumberValid(
 
 export async function altIsRegionPhoneNumberValid(
   { phoneNumber, regionCode }: { phoneNumber: string, regionCode: string }) {
-    const { phone } = await import('phone');
+    const { phone } = await import("phone");
     return phone(phoneNumber, { country: regionCode }).isValid;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,7 @@ export function isRegionPhoneNumberValid(
 
 export async function altIsRegionPhoneNumberValid(
   { phoneNumber, regionCode }: { phoneNumber: string, regionCode: string }) {
-    const { phone } = await import('phone')
+    const { phone } = await import('phone');
     return phone(phoneNumber, { country: regionCode }).isValid;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,12 +140,6 @@ export function isRegionPhoneNumberValid(
   return region.phoneRegex.test(phoneNumber);
 }
 
-export async function altIsRegionPhoneNumberValid(
-  { phoneNumber, regionCode }: { phoneNumber: string, regionCode: string }) {
-    const { phone } = await import("phone");
-    return phone(phoneNumber, { country: regionCode }).isValid;
-}
-
 export function getDefaultRegion(brand?: Brand) {
   return regions(brand)[0];
 }

--- a/src/phoneNumberValidation.test.ts
+++ b/src/phoneNumberValidation.test.ts
@@ -1,0 +1,117 @@
+import { expect } from "chai";
+import { isPhoneNumberValidForRegion } from "./phoneNumberValidation";
+
+describe("altIsRegionPhoneNumberValid", () => {
+  it("should return false for a phone number with non-numeric characters", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "41212ASD12", regionCode: "AU" });
+    expect(result).to.be.false;
+  });
+
+  it("should return false for a phone number with an international prefix", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "+61412121212", regionCode: "AU" });
+    expect(result).to.be.false;
+  });
+
+  it("should return true for a valid AU phone number", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "412121212", regionCode: "AU" });
+    expect(result).to.be.true;
+  });
+
+  it("should return false for an AU phone number with a trunk prefix", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "0412121212", regionCode: "AU" });
+    expect(result).to.be.false;
+  });
+
+  it("should return false if the phone number is not a valid number for the region AU", () => {
+    // 2102712121 is a valid NZ number, but not AU
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "2102712121", regionCode: "AU" });
+    expect(result).to.be.false;
+  })
+
+  it("should return false for an invalid AU phone number", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "212121212", regionCode: "AU" });
+    expect(result).to.be.false;
+  });
+
+
+  it("should return true for a valid NZ phone number", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "212121212", regionCode: "NZ" });
+    expect(result).to.be.true;
+  });
+
+  it("should return false for an invalid NZ phone number", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "021212121211", regionCode: "NZ" });
+    expect(result).to.be.false;
+  });
+
+  it("should return false for a NZ phone number with a trunk prefix", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "02102102102", regionCode: "NZ" });
+    expect(result).to.be.false;
+  });
+
+  it("should return true for a valid GB phone number", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "7912345678", regionCode: "GB" });
+    expect(result).to.be.true;
+  });
+
+  it("should return false for an invalid GB phone number", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "7912345678912", regionCode: "GB" });
+    expect(result).to.be.false;
+  });
+
+  it("should return true for a valid US phone number", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "2035671234", regionCode: "US" });
+    expect(result).to.be.true;
+  });
+
+  it("should return false for an invalid US phone number", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "20356712341123", regionCode: "US" });
+    expect(result).to.be.false;
+  });
+
+  it("should return false for a US phone number with an international prefix", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "+12035671234", regionCode: "US" });
+    expect(result).to.be.false;
+  });
+
+  it("should return true for a valid SG phone number", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "81234567", regionCode: "SG" });
+    expect(result).to.be.true;
+  });
+
+  it("should return false for an invalid SG phone number", () => {
+    // SG phone numbers should start with 6, 8, or 9
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "21234567", regionCode: "SG" });
+    expect(result).to.be.false;
+  });
+
+  it("should return true for a valid HK phone number", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "51234567", regionCode: "HK" });
+    expect(result).to.be.true;
+  });
+
+  it("should return false for an invalid HK phone number", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "512345678912", regionCode: "HK" });
+    expect(result).to.be.false;
+  });
+
+  it("should return true for a valid IN phone number", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "9123456789", regionCode: "IN" });
+    expect(result).to.be.true;
+  });
+
+  it("should return false for an invalid IN phone number", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "912345678912", regionCode: "IN" });
+    expect(result).to.be.false;
+  });
+
+  it("should return true for a valid BE phone number", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "478123456", regionCode: "BE" });
+    expect(result).to.be.true;
+  });
+
+  it("should return false for an invalid BE phone number", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "3123456", regionCode: "BE" });
+    expect(result).to.be.false;
+  });
+});

--- a/src/phoneNumberValidation.test.ts
+++ b/src/phoneNumberValidation.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { isPhoneNumberValidForRegion } from "./phoneNumberValidation";
 
-describe("altIsRegionPhoneNumberValid", () => {
+describe("isPhoneNumberValidForRegion", () => {
   it("should return false for a phone number with non-numeric characters", () => {
     const result = isPhoneNumberValidForRegion({ phoneNumber: "41212ASD12", regionCode: "AU" });
     expect(result).to.be.false;

--- a/src/phoneNumberValidation.test.ts
+++ b/src/phoneNumberValidation.test.ts
@@ -28,11 +28,10 @@ describe("isPhoneNumberValidForRegion", () => {
     expect(result).to.be.false;
   })
 
-  it("should return false for an invalid AU phone number", () => {
-    const result = isPhoneNumberValidForRegion({ phoneNumber: "212121212", regionCode: "AU" });
-    expect(result).to.be.false;
-  });
-
+  it("should return true if the phone number is a valid Australian landline phone number", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "212345678", regionCode: "AU" });
+    expect(result).to.be.true;
+  })
 
   it("should return true for a valid NZ phone number", () => {
     const result = isPhoneNumberValidForRegion({ phoneNumber: "212121212", regionCode: "NZ" });
@@ -79,11 +78,10 @@ describe("isPhoneNumberValidForRegion", () => {
     expect(result).to.be.true;
   });
 
-  it("should return false for an invalid SG phone number", () => {
-    // SG phone numbers should start with 6, 8, or 9
-    const result = isPhoneNumberValidForRegion({ phoneNumber: "21234567", regionCode: "SG" });
-    expect(result).to.be.false;
-  });
+  it("should return true for a valid SG landline phone number", () => {
+    const result = isPhoneNumberValidForRegion({ phoneNumber: "81234567", regionCode: "SG" });
+    expect(result).to.be.true;
+  })
 
   it("should return true for a valid HK phone number", () => {
     const result = isPhoneNumberValidForRegion({ phoneNumber: "51234567", regionCode: "HK" });
@@ -98,11 +96,6 @@ describe("isPhoneNumberValidForRegion", () => {
   it("should return true for a valid IN phone number", () => {
     const result = isPhoneNumberValidForRegion({ phoneNumber: "9123456789", regionCode: "IN" });
     expect(result).to.be.true;
-  });
-
-  it("should return false for an invalid IN phone number", () => {
-    const result = isPhoneNumberValidForRegion({ phoneNumber: "912345678912", regionCode: "IN" });
-    expect(result).to.be.false;
   });
 
   it("should return true for a valid BE phone number", () => {

--- a/src/phoneNumberValidation.ts
+++ b/src/phoneNumberValidation.ts
@@ -1,0 +1,6 @@
+import { phone } from "phone";
+
+export async function altIsRegionPhoneNumberValid(
+  { phoneNumber, regionCode }: { phoneNumber: string, regionCode: string }) {
+    return phone(phoneNumber, { country: regionCode }).isValid;
+}

--- a/src/phoneNumberValidation.ts
+++ b/src/phoneNumberValidation.ts
@@ -62,6 +62,7 @@ export function isPhoneNumberValidForRegion(
     const phoneNumberResult = phone(phoneNumber, {
       country: regionCode,
       strictDetection: true,
+      validateMobilePrefix: false,
     });
 
     return phoneNumberResult.isValid;

--- a/src/phoneNumberValidation.ts
+++ b/src/phoneNumberValidation.ts
@@ -3,42 +3,42 @@ import { phone } from "phone";
 const NON_NUMERICAL_CHARACTERS_REGEX = /[^0-9]/;
 
 const REGIONS_WITH_ZERO_TRUNK_PREFIX = new Set([
-  'AT', // Austria
-  'AU', // Australia
-  'BD', // Bangladesh
-  'BE', // Belgium
-  'BG', // Bulgaria
-  'CZ', // Czech Republic
-  'DE', // Germany
-  'DZ', // Algeria
-  'EG', // Egypt
-  'FI', // Finland
-  'FR', // France
-  'GB', // United Kingdom
-  'GR', // Greece
-  'ID', // Indonesia
-  'IE', // Ireland
-  'IN', // India
-  'IT', // Italy
-  'JP', // Japan
-  'KE', // Kenya
-  'MA', // Morocco
-  'MY', // Malaysia
-  'NG', // Nigeria
-  'NL', // Netherlands
-  'NZ', // New Zealand
-  'PH', // Philippines
-  'PK', // Pakistan
-  'PL', // Poland
-  'RO', // Romania
-  'SE', // Sweden
-  'CH', // Switzerland
-  'TH', // Thailand
-  'TR', // Turkey
-  'TZ', // Tanzania
-  'UG', // Uganda
-  'VN', // Vietnam
-  'ZA'  // South Africa
+  "AT", // Austria
+  "AU", // Australia
+  "BD", // Bangladesh
+  "BE", // Belgium
+  "BG", // Bulgaria
+  "CZ", // Czech Republic
+  "DE", // Germany
+  "DZ", // Algeria
+  "EG", // Egypt
+  "FI", // Finland
+  "FR", // France
+  "GB", // United Kingdom
+  "GR", // Greece
+  "ID", // Indonesia
+  "IE", // Ireland
+  "IN", // India
+  "IT", // Italy
+  "JP", // Japan
+  "KE", // Kenya
+  "MA", // Morocco
+  "MY", // Malaysia
+  "NG", // Nigeria
+  "NL", // Netherlands
+  "NZ", // New Zealand
+  "PH", // Philippines
+  "PK", // Pakistan
+  "PL", // Poland
+  "RO", // Romania
+  "SE", // Sweden
+  "CH", // Switzerland
+  "TH", // Thailand
+  "TR", // Turkey
+  "TZ", // Tanzania
+  "UG", // Uganda
+  "VN", // Vietnam
+  "ZA",  // South Africa
 ]);
 
 export function isPhoneNumberValidForRegion(
@@ -52,17 +52,17 @@ export function isPhoneNumberValidForRegion(
     // note: this will also capture any cases where there is an international country code attached to
     // the number (e.g. +61)
     if (NON_NUMERICAL_CHARACTERS_REGEX.test(phoneNumber)) {
-      return false
+      return false;
     }
 
-    if(REGIONS_WITH_ZERO_TRUNK_PREFIX.has(regionCode) && phoneNumber.startsWith('0')) {
-      return false
+    if (REGIONS_WITH_ZERO_TRUNK_PREFIX.has(regionCode) && phoneNumber.startsWith("0")) {
+      return false;
     }
 
-    const phoneNumberResult = phone(phoneNumber, { 
+    const phoneNumberResult = phone(phoneNumber, {
       country: regionCode,
-      strictDetection: true
+      strictDetection: true,
     });
 
-    return phoneNumberResult.isValid
+    return phoneNumberResult.isValid;
 }

--- a/src/phoneNumberValidation.ts
+++ b/src/phoneNumberValidation.ts
@@ -2,6 +2,277 @@ import { phone } from "phone";
 
 const NON_NUMERICAL_CHARACTERS_REGEX = /[^0-9]/;
 
+export const REGIONS_COUNTRY_CODES = {
+  "AD": {
+    countryName: "Andorra",
+    countryCode: "376",
+  },
+  "AE": {
+    countryName: "United Arab Emirates",
+    countryCode: "971",
+  },
+  "AL": {
+    countryName: "Albania",
+    countryCode: "355",
+  },
+  "AT": {
+    countryName: "Austria",
+    countryCode: "43",
+  },
+  "AU": {
+    countryName: "Australia",
+    countryCode: "61",
+  },
+  "BA": {
+    countryName: "Bosnia and Herzegovina",
+    countryCode: "387",
+  },
+  "BE": {
+    countryName: "Belgium",
+    countryCode: "32",
+  },
+  "BG": {
+    countryName: "Bulgaria",
+    countryCode: "359",
+  },
+  "BY": {
+    countryName: "Belarus",
+    countryCode: "375",
+  },
+  "CA": {
+    countryName: "Canada",
+    countryCode: "1",
+  },
+  "CH": {
+    countryName: "Switzerland",
+    countryCode: "41",
+  },
+  "CN": {
+    countryName: "China",
+    countryCode: "86",
+  },
+  "CY": {
+    countryName: "Cyprus",
+    countryCode: "357",
+  },
+  "CZ": {
+    countryName: "Czech Republic",
+    countryCode: "420",
+  },
+  "DE": {
+    countryName: "Germany",
+    countryCode: "49",
+  },
+  "DK": {
+    countryName: "Denmark",
+    countryCode: "45",
+  },
+  "EE": {
+    countryName: "Estonia",
+    countryCode: "372",
+  },
+  "ES": {
+    countryName: "Spain",
+    countryCode: "34",
+  },
+  "FI": {
+    countryName: "Finland",
+    countryCode: "358",
+  },
+  "FR": {
+    countryName: "France",
+    countryCode: "33",
+  },
+  "GB": {
+    countryName: "United Kingdom",
+    countryCode: "44",
+  },
+  "GR": {
+    countryName: "Greece",
+    countryCode: "30",
+  },
+  "HK": {
+    countryName: "Hong Kong",
+    countryCode: "852",
+  },
+  "HR": {
+    countryName: "Croatia",
+    countryCode: "385",
+  },
+  "HU": {
+    countryName: "Hungary",
+    countryCode: "36",
+  },
+  "ID": {
+    countryName: "Indonesia",
+    countryCode: "62",
+  },
+  "IE": {
+    countryName: "Ireland",
+    countryCode: "353",
+  },
+  "IL": {
+    countryName: "Israel",
+    countryCode: "972",
+  },
+  "IN": {
+    countryName: "India",
+    countryCode: "91",
+  },
+  "IS": {
+    countryName: "Iceland",
+    countryCode: "354",
+  },
+  "IT": {
+    countryName: "Italy",
+    countryCode: "39",
+  },
+  "JP": {
+    countryName: "Japan",
+    countryCode: "81",
+  },
+  "KR": {
+    countryName: "Korea",
+    countryCode: "82",
+  },
+  "LI": {
+    countryName: "Liechtenstein",
+    countryCode: "423",
+  },
+  "LT": {
+    countryName: "Lithuania",
+    countryCode: "370",
+  },
+  "LU": {
+    countryName: "Luxembourg",
+    countryCode: "352",
+  },
+  "LV": {
+    countryName: "Latvia",
+    countryCode: "371",
+  },
+  "MC": {
+    countryName: "Monaco",
+    countryCode: "377",
+  },
+  "MD": {
+    countryName: "Moldova",
+    countryCode: "373",
+  },
+  "ME": {
+    countryName: "Montenegro",
+    countryCode: "382",
+  },
+  "MK": {
+    countryName: "North Macedonia",
+    countryCode: "389",
+  },
+  "MO": {
+    countryName: "Macau",
+    countryCode: "853",
+  },
+  "MT": {
+    countryName: "Malta",
+    countryCode: "356",
+  },
+  "MY": {
+    countryName: "Malaysia",
+    countryCode: "60",
+  },
+  "NL": {
+    countryName: "Netherlands",
+    countryCode: "31",
+  },
+  "NO": {
+    countryName: "Norway",
+    countryCode: "47",
+  },
+  "NZ": {
+    countryName: "New Zealand",
+    countryCode: "64",
+  },
+  "PH": {
+    countryName: "Philippines",
+    countryCode: "63",
+  },
+  "PL": {
+    countryName: "Poland",
+    countryCode: "48",
+  },
+  "PT": {
+    countryName: "Portugal",
+    countryCode: "351",
+  },
+  "QA": {
+    countryName: "Qatar",
+    countryCode: "964",
+  },
+  "RO": {
+    countryName: "Romania",
+    countryCode: "40",
+  },
+  "RS": {
+    countryName: "Serbia",
+    countryCode: "381",
+  },
+  "RU": {
+    countryName: "Russia",
+    countryCode: "7",
+  },
+  "SA": {
+    countryName: "Saudi Arabia",
+    countryCode: "966",
+  },
+  "SE": {
+    countryName: "Sweden",
+    countryCode: "46",
+  },
+  "SG": {
+    countryName: "Singapore",
+    countryCode: "65",
+  },
+  "SI": {
+    countryName: "Slovenia",
+    countryCode: "386",
+  },
+  "SK": {
+    countryName: "Slovakia",
+    countryCode: "421",
+  },
+  "SM": {
+    countryName: "San Marino",
+    countryCode: "378",
+  },
+  "TH": {
+    countryName: "Thailand",
+    countryCode: "66",
+  },
+  "TW": {
+    countryName: "Taiwan",
+    countryCode: "886",
+  },
+  "UA": {
+    countryName: "Ukraine",
+    countryCode: "380",
+  },
+  "US": {
+    countryName: "United States",
+    countryCode: "1",
+  },
+  "VA": {
+    countryName: "Vatican City",
+    countryCode: "379",
+  },
+  "VN": {
+    countryName: "Vietnam",
+    countryCode: "84",
+  },
+  "ZA": {
+    countryName: "South Africa",
+    countryCode: "27",
+  }
+}
+
 const REGIONS_WITH_ZERO_TRUNK_PREFIX = new Set([
   "AT", // Austria
   "AU", // Australia

--- a/src/phoneNumberValidation.ts
+++ b/src/phoneNumberValidation.ts
@@ -1,6 +1,68 @@
 import { phone } from "phone";
 
-export async function altIsRegionPhoneNumberValid(
+const NON_NUMERICAL_CHARACTERS_REGEX = /[^0-9]/;
+
+const REGIONS_WITH_ZERO_TRUNK_PREFIX = new Set([
+  'AT', // Austria
+  'AU', // Australia
+  'BD', // Bangladesh
+  'BE', // Belgium
+  'BG', // Bulgaria
+  'CZ', // Czech Republic
+  'DE', // Germany
+  'DZ', // Algeria
+  'EG', // Egypt
+  'FI', // Finland
+  'FR', // France
+  'GB', // United Kingdom
+  'GR', // Greece
+  'ID', // Indonesia
+  'IE', // Ireland
+  'IN', // India
+  'IT', // Italy
+  'JP', // Japan
+  'KE', // Kenya
+  'MA', // Morocco
+  'MY', // Malaysia
+  'NG', // Nigeria
+  'NL', // Netherlands
+  'NZ', // New Zealand
+  'PH', // Philippines
+  'PK', // Pakistan
+  'PL', // Poland
+  'RO', // Romania
+  'SE', // Sweden
+  'CH', // Switzerland
+  'TH', // Thailand
+  'TR', // Turkey
+  'TZ', // Tanzania
+  'UG', // Uganda
+  'VN', // Vietnam
+  'ZA'  // South Africa
+]);
+
+export function isPhoneNumberValidForRegion(
   { phoneNumber, regionCode }: { phoneNumber: string, regionCode: string }) {
-    return phone(phoneNumber, { country: regionCode }).isValid;
+
+    // If the phone number has any non-numeric characters, return false
+    // We want to validate for this separately because the 3rd party library
+    // will return true as it will try to sanitize the phone number and return the validity against
+    // the region based on the sanitized number
+    //
+    // note: this will also capture any cases where there is an international country code attached to
+    // the number (e.g. +61)
+    if (NON_NUMERICAL_CHARACTERS_REGEX.test(phoneNumber)) {
+      return false
+    }
+
+    if(REGIONS_WITH_ZERO_TRUNK_PREFIX.has(regionCode) && phoneNumber.startsWith('0')) {
+      return false
+    }
+
+    const phoneNumberResult = phone(phoneNumber, { 
+      country: regionCode,
+      strictDetection: true
+    });
+
+    return phoneNumberResult.isValid
 }

--- a/src/phoneNumberValidation.ts
+++ b/src/phoneNumberValidation.ts
@@ -3,275 +3,275 @@ import { phone } from "phone";
 const NON_NUMERICAL_CHARACTERS_REGEX = /[^0-9]/;
 
 export const REGIONS_COUNTRY_CODES = {
-  "AD": {
+  AD: {
     countryName: "Andorra",
     countryCode: "376",
   },
-  "AE": {
+  AE: {
     countryName: "United Arab Emirates",
     countryCode: "971",
   },
-  "AL": {
+  AL: {
     countryName: "Albania",
     countryCode: "355",
   },
-  "AT": {
+  AT: {
     countryName: "Austria",
     countryCode: "43",
   },
-  "AU": {
+  AU: {
     countryName: "Australia",
     countryCode: "61",
   },
-  "BA": {
+  BA: {
     countryName: "Bosnia and Herzegovina",
     countryCode: "387",
   },
-  "BE": {
+  BE: {
     countryName: "Belgium",
     countryCode: "32",
   },
-  "BG": {
+  BG: {
     countryName: "Bulgaria",
     countryCode: "359",
   },
-  "BY": {
+  BY: {
     countryName: "Belarus",
     countryCode: "375",
   },
-  "CA": {
+  CA: {
     countryName: "Canada",
     countryCode: "1",
   },
-  "CH": {
+  CH: {
     countryName: "Switzerland",
     countryCode: "41",
   },
-  "CN": {
+  CN: {
     countryName: "China",
     countryCode: "86",
   },
-  "CY": {
+  CY: {
     countryName: "Cyprus",
     countryCode: "357",
   },
-  "CZ": {
+  CZ: {
     countryName: "Czech Republic",
     countryCode: "420",
   },
-  "DE": {
+  DE: {
     countryName: "Germany",
     countryCode: "49",
   },
-  "DK": {
+  DK: {
     countryName: "Denmark",
     countryCode: "45",
   },
-  "EE": {
+  EE: {
     countryName: "Estonia",
     countryCode: "372",
   },
-  "ES": {
+  ES: {
     countryName: "Spain",
     countryCode: "34",
   },
-  "FI": {
+  FI: {
     countryName: "Finland",
     countryCode: "358",
   },
-  "FR": {
+  FR: {
     countryName: "France",
     countryCode: "33",
   },
-  "GB": {
+  GB: {
     countryName: "United Kingdom",
     countryCode: "44",
   },
-  "GR": {
+  GR: {
     countryName: "Greece",
     countryCode: "30",
   },
-  "HK": {
+  HK: {
     countryName: "Hong Kong",
     countryCode: "852",
   },
-  "HR": {
+  HR: {
     countryName: "Croatia",
     countryCode: "385",
   },
-  "HU": {
+  HU: {
     countryName: "Hungary",
     countryCode: "36",
   },
-  "ID": {
+  ID: {
     countryName: "Indonesia",
     countryCode: "62",
   },
-  "IE": {
+  IE: {
     countryName: "Ireland",
     countryCode: "353",
   },
-  "IL": {
+  IL: {
     countryName: "Israel",
     countryCode: "972",
   },
-  "IN": {
+  IN: {
     countryName: "India",
     countryCode: "91",
   },
-  "IS": {
+  IS: {
     countryName: "Iceland",
     countryCode: "354",
   },
-  "IT": {
+  IT: {
     countryName: "Italy",
     countryCode: "39",
   },
-  "JP": {
+  JP: {
     countryName: "Japan",
     countryCode: "81",
   },
-  "KR": {
+  KR: {
     countryName: "Korea",
     countryCode: "82",
   },
-  "LI": {
+  LI: {
     countryName: "Liechtenstein",
     countryCode: "423",
   },
-  "LT": {
+  LT: {
     countryName: "Lithuania",
     countryCode: "370",
   },
-  "LU": {
+  LU: {
     countryName: "Luxembourg",
     countryCode: "352",
   },
-  "LV": {
+  LV: {
     countryName: "Latvia",
     countryCode: "371",
   },
-  "MC": {
+  MC: {
     countryName: "Monaco",
     countryCode: "377",
   },
-  "MD": {
+  MD: {
     countryName: "Moldova",
     countryCode: "373",
   },
-  "ME": {
+  ME: {
     countryName: "Montenegro",
     countryCode: "382",
   },
-  "MK": {
+  MK: {
     countryName: "North Macedonia",
     countryCode: "389",
   },
-  "MO": {
+  MO: {
     countryName: "Macau",
     countryCode: "853",
   },
-  "MT": {
+  MT: {
     countryName: "Malta",
     countryCode: "356",
   },
-  "MY": {
+  MY: {
     countryName: "Malaysia",
     countryCode: "60",
   },
-  "NL": {
+  NL: {
     countryName: "Netherlands",
     countryCode: "31",
   },
-  "NO": {
+  NO: {
     countryName: "Norway",
     countryCode: "47",
   },
-  "NZ": {
+  NZ: {
     countryName: "New Zealand",
     countryCode: "64",
   },
-  "PH": {
+  PH: {
     countryName: "Philippines",
     countryCode: "63",
   },
-  "PL": {
+  PL: {
     countryName: "Poland",
     countryCode: "48",
   },
-  "PT": {
+  PT: {
     countryName: "Portugal",
     countryCode: "351",
   },
-  "QA": {
+  QA: {
     countryName: "Qatar",
     countryCode: "964",
   },
-  "RO": {
+  RO: {
     countryName: "Romania",
     countryCode: "40",
   },
-  "RS": {
+  RS: {
     countryName: "Serbia",
     countryCode: "381",
   },
-  "RU": {
+  RU: {
     countryName: "Russia",
     countryCode: "7",
   },
-  "SA": {
+  SA: {
     countryName: "Saudi Arabia",
     countryCode: "966",
   },
-  "SE": {
+  SE: {
     countryName: "Sweden",
     countryCode: "46",
   },
-  "SG": {
+  SG: {
     countryName: "Singapore",
     countryCode: "65",
   },
-  "SI": {
+  SI: {
     countryName: "Slovenia",
     countryCode: "386",
   },
-  "SK": {
+  SK: {
     countryName: "Slovakia",
     countryCode: "421",
   },
-  "SM": {
+  SM: {
     countryName: "San Marino",
     countryCode: "378",
   },
-  "TH": {
+  TH: {
     countryName: "Thailand",
     countryCode: "66",
   },
-  "TW": {
+  TW: {
     countryName: "Taiwan",
     countryCode: "886",
   },
-  "UA": {
+  UA: {
     countryName: "Ukraine",
     countryCode: "380",
   },
-  "US": {
+  US: {
     countryName: "United States",
     countryCode: "1",
   },
-  "VA": {
+  VA: {
     countryName: "Vatican City",
     countryCode: "379",
   },
-  "VN": {
+  VN: {
     countryName: "Vietnam",
     countryCode: "84",
   },
-  "ZA": {
+  ZA: {
     countryName: "South Africa",
     countryCode: "27",
-  }
-}
+  },
+};
 
 const REGIONS_WITH_ZERO_TRUNK_PREFIX = new Set([
   "AT", // Austria

--- a/yarn.lock
+++ b/yarn.lock
@@ -587,6 +587,11 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+libphonenumber-js@^1.11.20:
+  version "1.11.20"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.11.20.tgz#ef5c663e80f55d9ea01a6e2952bf240e8a6fff52"
+  integrity sha512-/ipwAMvtSZRdiQBHqW1qxqeYiBMzncOQLVA+62MWYr7N4m7Q2jqpJ0WgT7zlOEOpyLRSqrMXidbJpC0J77AaKA==
+
 locate-path@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
@@ -835,7 +840,16 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -853,7 +867,14 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -982,7 +1003,16 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -587,11 +587,6 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-libphonenumber-js@^1.11.20:
-  version "1.11.20"
-  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.11.20.tgz#ef5c663e80f55d9ea01a6e2952bf240e8a6fff52"
-  integrity sha512-/ipwAMvtSZRdiQBHqW1qxqeYiBMzncOQLVA+62MWYr7N4m7Q2jqpJ0WgT7zlOEOpyLRSqrMXidbJpC0J77AaKA==
-
 locate-path@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
@@ -762,6 +757,11 @@ pathval@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
+
+phone@^3.1.58:
+  version "3.1.58"
+  resolved "https://registry.yarnpkg.com/phone/-/phone-3.1.58.tgz#af0523fc3d2d840e46d47fb4118845f0bc38babd"
+  integrity sha512-4R4qfXxNPpl08fxOH0qvTXTodQue0nCnAQP0OIu2i59TDq4QXM0dq/b7ODPNH93setqK5YdMSiMuce0RPsgu4w==
 
 picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.1"


### PR DESCRIPTION
## Story tracking
https://aussiecommerce.atlassian.net/browse/OPEX-3004

We want to improve how phone numbers are validated. The existing implementation doesn't scale too well as we are defining a regex for each region that needs to be supported by LE.

In response to this limitation, this PR does the following:
- Consume a lightweight 3rd party package to assist in validating phone numbers by region
  - This will improve maintenance effort in the long run as we don't have to maintain our own regex patterns for each region that needs to be supported by LE
- Create a new `isPhoneNumberValidForRegion` function which will serve as the centralised function where phone numbers are validated by region
- Maintain a separate list of regions we want to support phone numbers for
  - Current list only supports specific markets where LE is available. But the list we need to provide should support a much greater number of regions than this market
- Add unit tests