### PR TITLE
[CRO 5055] Updated region start order

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.53",
+  "version": "5.6.54",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -18,16 +18,16 @@ describe("getRegionCodesSortedByKeyRegions", () => {
     regionModule.getRegionCodesSortedByKeyRegions();
 
   it("should return key region codes sorted and as initial elements", () => {
-    const keyRegionCodes = allRegionCodes.slice(0, 7);
-    expect(keyRegionCodes).to.deep.equal(["AU", "US", "GB", "NZ", "SG", "HK", "TW"]);
+    const keyRegionCodes = allRegionCodes.slice(0, 10);
+    expect(keyRegionCodes).to.deep.equal(["AU", "US", "GB", "NZ", "SG", "HK", "TW", "ZA", "QA", "MY"]);
   });
 
   it("should return the index of last key region", () => {
-    expect(lastKeyRegionIndex).to.be.equal(6);
+    expect(lastKeyRegionIndex).to.be.equal(9);
   });
 
   it("should return other region codes sorted and after key region codes", () => {
-    const otherRegionCodes = allRegionCodes.slice(7, 12);
+    const otherRegionCodes = allRegionCodes.slice(10, 15);
     expect(otherRegionCodes).to.deep.equal(["CA", "CN", "FR", "DE", "IN"]);
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ const zeroDecimalCurrencies = [
 ];
 
 // Custom order of countries that are more important to LE, showing it before other countries on CP and admin
-const REGIONS_START_ORDER = ["AU", "US", "GB", "NZ", "SG", "HK", "TW"];
+const REGIONS_START_ORDER = ["AU", "US", "GB", "NZ", "SG", "HK", "TW", "ZA", "QA", "MY"];
 
 export function getPriorityPhoneNumbers(brand?: string) {
   return priorityPhoneNumbers[brand || LUXURY_ESCAPES];


### PR DESCRIPTION
Jira: https://aussiecommerce.atlassian.net/jira/software/projects/CRO/boards/114?selectedIssue=CRO-5055

Why these changes are needed:
- We are starting to invest more marketing effort in growing South Africa, Qatar and Malaysia
- We need to add South Africa, Malaysia, and Qatar to this top section (below Taiwan, above the hr)

![image](https://github.com/user-attachments/assets/aeac1e1a-329a-4721-9979-9651a21749a9)
