### PR TITLE
Fix/OPEX-3176 offer FJD currency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.58",
+  "version": "5.6.59-beta.0",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.59-beta.0",
+  "version": "5.6.59-beta.1",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -233,6 +233,12 @@ export const currencies: BrandCurrencies = {
         "stripe_payment_element_klarna",
       ],
     },
+    FJD: {
+      paymentMethods: [
+        "le_credit",
+        "stripe",
+      ],
+    },
     HKD: {
       paymentMethods: [
         "le_credit",
@@ -515,20 +521,20 @@ export const currencies: BrandCurrencies = {
     },
   },
   newwhitelabel: {
-      AUD: {
-        paymentMethods: [
-          "le_credit",
-          "stripe",
-          "braintree",
-          "qantas",
-          "giftcard",
-          "bridgerpay",
-          "applepay",
-          "googlepay",
-          "afterpay_bp",
-          "stripe_3ds",
-          "stripe_payment_element_card",
-        ],
-      },
+    AUD: {
+      paymentMethods: [
+        "le_credit",
+        "stripe",
+        "braintree",
+        "qantas",
+        "giftcard",
+        "bridgerpay",
+        "applepay",
+        "googlepay",
+        "afterpay_bp",
+        "stripe_3ds",
+        "stripe_payment_element_card",
+      ],
+    },
   },
 };


### PR DESCRIPTION
Summary: 
- Need to offer FJD as currency for Custom Offers (Admin Portal -> Vendor Currency)

Fix: 
- Updated the LE currencies map to include `FJD` currency.
- Supporting standard payment methods of `le_credit` and `stripe`.

