### PR TITLE
feat(PayPal): [PP-2644] enable for whitelabel brands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-regions",
-  "version": "5.6.60",
+  "version": "5.6.61",
   "description": "Region information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -27,7 +27,7 @@ export const currencies: BrandCurrencies = {
     AUD: {
       paymentMethods: [
         "stripe",
-        "braintree",
+        "paypal",
         "stripe_3ds",
         "giftcard",
         "stripe_payment_element_card",
@@ -40,7 +40,7 @@ export const currencies: BrandCurrencies = {
     AUD: {
       paymentMethods: [
         "stripe",
-        "braintree",
+        "paypal",
         "stripe_3ds",
         "giftcard",
         "stripe_payment_element_card",
@@ -96,7 +96,7 @@ export const currencies: BrandCurrencies = {
       paymentMethods: [
         "applepay",
         "stripe",
-        "braintree",
+        "paypal",
         "stripe_3ds",
         "giftcard",
         "stripe_custom_payto",
@@ -175,7 +175,6 @@ export const currencies: BrandCurrencies = {
         "le_credit",
         "stripe",
         "deposit_stripe",
-        "braintree",
         "qantas",
         "giftcard",
         "bridgerpay",
@@ -521,7 +520,7 @@ export const currencies: BrandCurrencies = {
         paymentMethods: [
           "le_credit",
           "stripe",
-          "braintree",
+          "paypal",
           "qantas",
           "giftcard",
           "bridgerpay",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -255,7 +255,7 @@ describe("getPaymentMethodsByCurrencyCode()", function () {
   it("should return an array of payment methods", function () {
     expect(
       regionModule.getPaymentMethodsByCurrencyCode("AUD", "scoopontravel")
-    ).to.deep.equal(["applepay", "stripe", "braintree", "stripe_3ds", "giftcard", "stripe_custom_payto", "stripe_payment_element_card", "googlepay"]);
+    ).to.deep.equal(["applepay", "stripe", "paypal", "stripe_3ds", "giftcard", "stripe_custom_payto", "stripe_payment_element_card", "googlepay"]);
     expect(
       regionModule.getPaymentMethodsByCurrencyCode("AUD", "kogantravel")
     ).to.deep.equal(["stripe", "braintree", "stripe_3ds", "giftcard", "stripe_payment_element_card"]);
@@ -266,7 +266,6 @@ describe("getPaymentMethodsByCurrencyCode()", function () {
       "le_credit",
       "stripe",
       "deposit_stripe",
-      "braintree",
       "qantas",
       "giftcard",
       "bridgerpay",


### PR DESCRIPTION
## Story tracking
Jira: https://aussiecommerce.atlassian.net/browse/PP-2644

## Why is this change happening?
We want to turn on PayPal for whitelabel brands

## Summary of the change (from a product/customer perspective)


## Summary of key technical changes
Enable PayPal for:
* Deals
* Scoopon
* Cudo

## What have you done to test it?


Have you:

* [ ] Written tests? Or explained why not?
* [ ] Checked Coverage tests output and ensure passed our threshold? PaymentSchedule (80%)


* [ ] Does this change include the export of PII data to a third party? If yes to any, then an ADR is required.
  * name
  * email
  * address
  * DOB
  * phone number
  * Passport number

* [ ] Have you written comments? Comments should explain the 'why' and not 'what' the code is doing, such as a business requirement that is contrary to our regular flow.

* [ ] Do you agree to ensure that any dependencies that rely on this change will be deployed before the PR is merged.
